### PR TITLE
collectIssues 함수 수정 요청에 대한 PR

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,7 @@ const options = program.opts();
 
         // Collect data
         console.log('Collecting data...');
-        await analyzer.collectPRs();
-        await analyzer.collectIssues();
+        await analyzer.collectPRsAndIssues();
 
         // Calculate scores
         const scores = analyzer.calculateScores();
@@ -30,7 +29,7 @@ const options = program.opts();
         }
         if (options.format === 'chart' || options.format === 'both') {
             await analyzer.generateChart(scores);
-            console.log('Chart saved as participation_chart.png');
+            // console.log('Chart saved as participation_chart.png');
         }
     } catch (error) {
         console.error(`Error: ${error.message}`);

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -5,60 +5,97 @@ class RepoAnalyzer {
     constructor(repoPath) {
         this.repoPath = repoPath;
         this.participants = new Map();
-        this.octokit = new Octokit(); // Still included but unused in stubs
+        this.octokit = new Octokit();
     }
         
-    async collectPRs(){ // 병합된 PR의 수를 사용자별로 합산한 후 this.participants에 저장.
-        console.log('Collecting pull reqeusts...');
-        const [owner, repo] = this.repoPath.split('/') // 레퍼지토리 주소를 분할해 소유자와 레퍼지토리의 이름을 저장.
-        try{
-            let page = 1; // 1페이지부터 탐색
-            while(true){
-                const {data : PRs} = await this.octokit.rest.pulls.list({
-                    owner, 
-                    repo, 
-                    state: 'closed', // 닫힌 PR만 가져오기.
-                    per_page: 100, // 한 페이지에서 최대 100개의 PR데이터를 가져옴.
-                    page 
-                }); 
 
+    async collectPRsAndIssues() {
+        console.log('Collecting PRs and issues...');
 
-                PRs.forEach(pr => { // PRs를 순회.
-                    if (pr.merged_at !== null) { // 해당 PR이 병합되었을때만 횟수를 추가.
-                        if (this.participants.has(pr.user.login)){ // participants에 이미 추가된 사용자라면 pullRequests값을 + 1.
-                            this.participants.get(pr.user.login).pullRequests += 1;
+        const [owner, repo] = this.repoPath.split('/') // 사용자, 저장소 이름 추출
+        let page = 1
+
+        // 확인용 카운터, 추후 제거.
+        let bugFeatPRcnt = 0, docPRcnt = 0;
+        let bugFeatissueCnt = 0, docissueCnt = 0;
+
+        while(true){
+            const {data : response} = await this.octokit.rest.issues.listForRepo({ // 이슈(일반 이슈 + PR) 데이터를 요청.
+                owner, 
+                repo, 
+                state: 'all',
+                per_page: 100,
+                page
+            });
+
+            response.forEach(issue => {
+                if (!this.participants.has(issue.user.login)){ // 존재하지 않는 사용자라면 초기화.
+                    this.participants.set(issue.user.login, {
+                        pullRequests : {bugAndFeat : 0, doc : 0}, 
+                        issues : {bugAndFeat : 0, doc : 0}, 
+                        comments : 0
+                    });
+                }
+
+                if (issue.pull_request !== undefined){  // PR인 경우.
+                    if (issue.pull_request.merged_at !== null) {  // PR이 병합되었는지 확인.
+                        // 라벨에 따른 분류, 라벨은 문서, 기능, 버그 세 종류만 존재하며 한 이슈/PR에 하나의 라벨만 붙는다고 가정. 라벨이 없다면 개수를 추가하지 않음.
+                        if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){  
+                            this.participants.get(issue.user.login).pullRequests.doc += 1
+                            docPRcnt++;
                         }
-                        else { // 존재하지 않는 사용자라면 '사용자명' => {pullRequests : 1, issues : 0, comments : 0}으로 초기화.
-                            this.participants.set(pr.user.login, {pullRequests : 1, issues : 0, comments : 0})
+                        else if (issue.labels.length != 0){
+                            this.participants.get(issue.user.login).pullRequests.bugAndFeat += 1
+                            bugFeatPRcnt++;
                         }
                     }
-                })
-
-                if (PRs.length < 100) { // 마지막 페이지라면 루프 탈출.
-                    break;
                 }
-                page++; // 다음 페이지로 넘김.
-            }
-        } catch (error) {
-            console.error(`Error: ${error.message}`);
-            process.exit(1);
-        }
-    }
+                else { // 이슈인 경우.
+                    if ( // 반려된 이슈들을 제외시킴.
+                        issue.state_reason == 'completed' ||  // 정상적으로 닫힌 이슈.
+                        issue.state_reason == null ||         // 아직 열려있는 이슈는 null로 표시됨.
+                        issue.state_reason == 'reopened'      // 닫혔던 이슈가 다시 열린 경우.
+                    ){
+                        if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){
+                            this.participants.get(issue.user.login).issues.doc += 1
+                            docissueCnt++;
+                        }
+                        else if (issue.labels.length != 0){
+                            this.participants.get(issue.user.login).issues.bugAndFeat += 1
+                            bugFeatissueCnt++;
+                        }
+                    } 
+                }
+            });
 
-    async collectIssues() {
-        console.log('Collecting issues...');
-        // Deterministic stub data, building on commit data
-        this.participants.forEach((data, name) => {
-            data.issues = 2;    // Fixed: 2 issues per participant
-            data.comments = 3;  // Fixed: 3 comments per participant
-        });
-        // Add a new participant with fixed values
-        if (!this.participants.has('charlie')) {
-            this.participants.set('charlie', { commits: 1, issues: 2, comments: 3 });
+            if (response.length < 100){ // 마지막 페이지라면 루프를 탈출.
+                break;
+            }
+            page++; // 다음 페이지로 넘어감.
         }
+
+        // 확인용 console.log, 추후 제거.
+        
+        console.log('\n***수집한 정보를 출력합니다.***\n')
+        this.participants.forEach((value, key) => {
+            console.log(
+                `${key}\n`+ 
+                `bug and faeture PR : ${value.pullRequests.bugAndFeat}\n`+
+                `documents PR : ${value.pullRequests.doc}\n`+
+                `bug and faeture issues : ${value.issues.bugAndFeat}\n`+ 
+                `documents issues : ${value.issues.doc}\n`)
+        })
+        
+        console.log('\n***total***\n')
+        console.log(`bug and Feat PRs : ${bugFeatPRcnt}`)
+        console.log(`doc PRs : ${docPRcnt}`)
+        console.log(`bug and Feat issues : ${bugFeatissueCnt}`)
+        console.log(`doc issues : ${docissueCnt}\n`)
     }
 
     calculateScores() {
+        console.log('"calculateScores"함수가 아직 구현되지 않았습니다.')
+        /*
         const scores = {};
         for (const [participant, data] of this.participants) {
             scores[participant] = (data.pullRequests || 0) * 0.4 +
@@ -66,17 +103,24 @@ class RepoAnalyzer {
                                  (data.comments || 0) * 0.3;
         }
         return scores;
+        */
     }
 
     generateTable(scores) {
+        console.log('"generateTable"함수가 아직 구현되지 않았습니다.')
+        /*
         const table = new Table({ head: ['Participant', 'Score'] });
         Object.entries(scores).forEach(([name, score]) => table.push([name, score.toFixed(2)]));
         console.log(table.toString());
+        */
     }
 
     async generateChart(scores) {
+        console.log('"generateChart"함수가 아직 구현되지 않았습니다.')
+        /*
         // Placeholder: Requires a charting library and canvas setup for CLI
         console.log('Chart generation placeholder');
+        */
     }
 }
 


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/6 해당 이슈의 collectIssues 함수 수정 요청에 대한 PR입니다.

**Specify version (commit id).**
945573ef7b78a83ea1ba4214b2b2bab7d2f2e94a

**구현내용**
이슈를 수집하는 collectIssues 함수 구현 도중, PR또한 이슈의 일종이라는 것을 알게 되어 기존의 collectPRs를 제거 후 PR과 이슈를 한번에 처리하는 collectPRsAndIssues 함수를 구현하였습니다. 
라벨이 없는 PR과 이슈는 합산되지 않으며,  라벨을 통해 버그/기능, 문서로 나누어 수집하였습니다. 이로 인해 participants의 각 엔트리가 다음과 같이 변경되었습니다.
```
사용자 => {
      pullRequests : {bugAndFeat : 0, doc : 0}, 
      issues : {bugAndFeat : 0, doc : 0}, 
      comments : 0
  }
```
participants의 구조가 변경되어 아직 구현되지 않은 calculateScores 함수의 더미 코드에서 오류가 발생하여 아직 구현되지 않은 
함수의 더미 코드는 주석 처리를 하였고, '함수가 아직 구현되지 않았습니다'를 출력하도록 하였습니다.