### PR TITLE
[FEAT] 선택적 인증 기능 구현 요청에 대한 PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 Usage: index [options]
 
 Options:
-  -a, --api-key <token>', Github Access Token (optional)
+  -a, --api-key <token>, Github Access Token (optional)
   -r, --repo <path>    Repository path (e.g., user/repo)
   -o, --output <dir>   Output directory (default: "results")
   -f, --format <type>  Output format (table, chart, both) (default: "both")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 Usage: index [options]
 
 Options:
-  -a, --api-key <token>, Github Access Token (optional)
+  -a, --api-key <token> Github Access Token (optional)
   -r, --repo <path>    Repository path (e.g., user/repo)
   -o, --output <dir>   Output directory (default: "results")
   -f, --format <type>  Output format (table, chart, both) (default: "both")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install
 Usage: index [options]
 
 Options:
-  -a, --api-key <token>', 'Github Access Token (optional)
+  -a, --api-key <token>', Github Access Token (optional)
   -r, --repo <path>    Repository path (e.g., user/repo)
   -o, --output <dir>   Output directory (default: "results")
   -f, --format <type>  Output format (table, chart, both) (default: "both")

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ npm install
 Usage: index [options]
 
 Options:
+  -a, --api-key <token>', 'Github Access Token (optional)
   -r, --repo <path>    Repository path (e.g., user/repo)
   -o, --output <dir>   Output directory (default: "results")
   -f, --format <type>  Output format (table, chart, both) (default: "both")

--- a/index.js
+++ b/index.js
@@ -3,7 +3,9 @@
 const { program } = require('commander');
 const RepoAnalyzer = require('./lib/analyzer');
 
+
 program
+    .option('-a, --api-key <token>', 'Github Access Token (optional)')
     .option('-r, --repo <path>', 'Repository path (e.g., user/repo)')
     .option('-o, --output <dir>', 'Output directory', 'results')
     .option('-f, --format <type>', 'Output format (table, chart, both)', 'both');
@@ -13,8 +15,10 @@ const options = program.opts();
 
 (async () => {
     try {
+
         // Initialize analyzer with repo path
-        const analyzer = new RepoAnalyzer(options.repo);
+        const analyzer = new RepoAnalyzer(options.repo, options.apiKey);
+        await analyzer.validateToken();
 
         // Collect data
         console.log('Collecting data...');
@@ -22,6 +26,8 @@ const options = program.opts();
 
         // Calculate scores
         const scores = analyzer.calculateScores();
+
+
 
         // Generate outputs based on format
         if (options.format === 'table' || options.format === 'both') {

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -2,10 +2,30 @@ const { Octokit } = require('@octokit/rest');
 const Table = require('cli-table3');
 
 class RepoAnalyzer {
-    constructor(repoPath) {
+    constructor(repoPath, token) {
         this.repoPath = repoPath;
+        this.token = token; // 자신의 github token
         this.participants = new Map();
-        this.octokit = new Octokit();
+        this.octokit = token ? new Octokit({auth: token}) : new Octokit(); // 토큰이 등록되었을 경우 인증, 안되었을 경우는 비인증 상태로 진행
+    }
+
+    async validateToken(){ // API 토큰 인증
+        if(!this.token){
+            console.log('등록된 토큰이 없어 비인증 상태로 진행합니다.');
+            return;
+        }
+        console.log('토큰 인증을 진행합니다...')
+        try{
+            await this.octokit.rest.users.getAuthenticated();
+            console.log('토큰이 정상적으로 등록되었습니다.');
+        }catch(error){
+            if(error.status == 401){
+                throw new Error('Github 토큰 인증에 실패하여 프로그램을 종료합니다, 유효한 토큰인지 확인해주세요.');
+            }else{
+                throw new Error(`Github 토큰 인증 중 오류가 발생했습니다. ${error.message}`);
+
+            }
+        }
     }
         
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,327 @@
+{
+    "name": "repo-analyzer",
+    "version": "0.1.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "repo-analyzer",
+            "version": "0.1.0",
+            "dependencies": {
+                "@octokit/rest": "^19.0.0",
+                "cli-table3": "^0.6.0",
+                "commander": "^9.0.0"
+            },
+            "bin": {
+                "repo-analyzer": "index.js"
+            }
+        },
+        "node_modules/@colors/colors": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+            "optional": true,
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/@octokit/auth-token": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+            "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+            "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+            "dependencies": {
+                "@octokit/auth-token": "^3.0.0",
+                "@octokit/graphql": "^5.0.0",
+                "@octokit/request": "^6.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^9.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+            "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+            "dependencies": {
+                "@octokit/types": "^9.0.0",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+            "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+            "dependencies": {
+                "@octokit/request": "^6.0.0",
+                "@octokit/types": "^9.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "18.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
+            "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw=="
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+            "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
+            "dependencies": {
+                "@octokit/tsconfig": "^1.0.2",
+                "@octokit/types": "^9.2.3"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=4"
+            }
+        },
+        "node_modules/@octokit/plugin-request-log": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
+            "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
+            "dependencies": {
+                "@octokit/types": "^10.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+            "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+            "dependencies": {
+                "@octokit/openapi-types": "^18.0.0"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "6.2.8",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+            "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+            "dependencies": {
+                "@octokit/endpoint": "^7.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^9.0.0",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
+            "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+            "dependencies": {
+                "@octokit/types": "^9.0.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/rest": {
+            "version": "19.0.13",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
+            "integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
+            "dependencies": {
+                "@octokit/core": "^4.2.1",
+                "@octokit/plugin-paginate-rest": "^6.1.2",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/tsconfig": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+            "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
+        },
+        "node_modules/@octokit/types": {
+            "version": "9.3.2",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+            "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+            "dependencies": {
+                "@octokit/openapi-types": "^18.0.0"
+            }
+        },
+        "node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/before-after-hook": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+        },
+        "node_modules/cli-table3": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+            "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+            "dependencies": {
+                "string-width": "^4.2.0"
+            },
+            "engines": {
+                "node": "10.* || >= 12.*"
+            },
+            "optionalDependencies": {
+                "@colors/colors": "1.5.0"
+            }
+        },
+        "node_modules/commander": {
+            "version": "9.5.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+            "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+            "engines": {
+                "node": "^12.20.0 || >=14"
+            }
+        },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+        },
+        "node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/node-fetch": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+            }
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "repo-analyzer",
             "version": "0.1.0",
             "dependencies": {
-                "@octokit/rest": "^19.0.0",
+                "@octokit/rest": "^20.1.1",
                 "cli-table3": "^0.6.0",
                 "commander": "^9.0.0"
             },
@@ -26,160 +26,158 @@
             }
         },
         "node_modules/@octokit/auth-token": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
-            "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+            "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+            "license": "MIT",
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/core": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
-            "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+            "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
+            "license": "MIT",
             "dependencies": {
-                "@octokit/auth-token": "^3.0.0",
-                "@octokit/graphql": "^5.0.0",
-                "@octokit/request": "^6.0.0",
-                "@octokit/request-error": "^3.0.0",
-                "@octokit/types": "^9.0.0",
+                "@octokit/auth-token": "^4.0.0",
+                "@octokit/graphql": "^7.1.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.0.0",
                 "before-after-hook": "^2.2.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/endpoint": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
-            "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
+            "version": "9.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+            "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+            "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^9.0.0",
-                "is-plain-object": "^5.0.0",
+                "@octokit/types": "^13.1.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/graphql": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
-            "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+            "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+            "license": "MIT",
             "dependencies": {
-                "@octokit/request": "^6.0.0",
-                "@octokit/types": "^9.0.0",
+                "@octokit/request": "^8.4.1",
+                "@octokit/types": "^13.0.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/openapi-types": {
-            "version": "18.1.1",
-            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.1.1.tgz",
-            "integrity": "sha512-VRaeH8nCDtF5aXWnjPuEMIYf1itK/s3JYyJcWFJT8X9pSNnBtriDf7wlEWsGuhPLl4QIH4xM8fqTXDwJ3Mu6sw=="
+            "version": "24.2.0",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+            "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+            "license": "MIT"
         },
         "node_modules/@octokit/plugin-paginate-rest": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
-            "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
+            "version": "11.4.4-cjs.2",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.4.4-cjs.2.tgz",
+            "integrity": "sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==",
+            "license": "MIT",
             "dependencies": {
-                "@octokit/tsconfig": "^1.0.2",
-                "@octokit/types": "^9.2.3"
+                "@octokit/types": "^13.7.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=4"
+                "@octokit/core": "5"
             }
         },
         "node_modules/@octokit/plugin-request-log": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
-            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+            "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 18"
+            },
             "peerDependencies": {
-                "@octokit/core": ">=3"
+                "@octokit/core": "5"
             }
         },
         "node_modules/@octokit/plugin-rest-endpoint-methods": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
-            "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
+            "version": "13.3.2-cjs.1",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.2-cjs.1.tgz",
+            "integrity": "sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==",
+            "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^10.0.0"
+                "@octokit/types": "^13.8.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             },
             "peerDependencies": {
-                "@octokit/core": ">=3"
-            }
-        },
-        "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
-            "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
-            "dependencies": {
-                "@octokit/openapi-types": "^18.0.0"
+                "@octokit/core": "^5"
             }
         },
         "node_modules/@octokit/request": {
-            "version": "6.2.8",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
-            "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+            "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+            "license": "MIT",
             "dependencies": {
-                "@octokit/endpoint": "^7.0.0",
-                "@octokit/request-error": "^3.0.0",
-                "@octokit/types": "^9.0.0",
-                "is-plain-object": "^5.0.0",
-                "node-fetch": "^2.6.7",
+                "@octokit/endpoint": "^9.0.6",
+                "@octokit/request-error": "^5.1.1",
+                "@octokit/types": "^13.1.0",
                 "universal-user-agent": "^6.0.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/request-error": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.3.tgz",
-            "integrity": "sha512-crqw3V5Iy2uOU5Np+8M/YexTlT8zxCfI+qu+LxUB7SZpje4Qmx3mub5DfEKSO8Ylyk0aogi6TYdf6kxzh2BguQ==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+            "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+            "license": "MIT",
             "dependencies": {
-                "@octokit/types": "^9.0.0",
+                "@octokit/types": "^13.1.0",
                 "deprecation": "^2.0.0",
                 "once": "^1.4.0"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
         "node_modules/@octokit/rest": {
-            "version": "19.0.13",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
-            "integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
+            "version": "20.1.2",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.2.tgz",
+            "integrity": "sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==",
+            "license": "MIT",
             "dependencies": {
-                "@octokit/core": "^4.2.1",
-                "@octokit/plugin-paginate-rest": "^6.1.2",
-                "@octokit/plugin-request-log": "^1.0.4",
-                "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
+                "@octokit/core": "^5.0.2",
+                "@octokit/plugin-paginate-rest": "11.4.4-cjs.2",
+                "@octokit/plugin-request-log": "^4.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "13.3.2-cjs.1"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 18"
             }
         },
-        "node_modules/@octokit/tsconfig": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
-            "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
-        },
         "node_modules/@octokit/types": {
-            "version": "9.3.2",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
-            "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
+            "version": "13.10.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+            "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+            "license": "MIT",
             "dependencies": {
-                "@octokit/openapi-types": "^18.0.0"
+                "@octokit/openapi-types": "^24.2.0"
             }
         },
         "node_modules/ansi-regex": {
@@ -193,7 +191,8 @@
         "node_modules/before-after-hook": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
+            "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/cli-table3": {
             "version": "0.6.5",
@@ -220,7 +219,8 @@
         "node_modules/deprecation": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+            "license": "ISC"
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -235,37 +235,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-plain-object": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-            "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+            "license": "ISC",
             "dependencies": {
                 "wrappy": "1"
             }
@@ -294,34 +268,17 @@
                 "node": ">=8"
             }
         },
-        "node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-        },
         "node_modules/universal-user-agent": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ=="
-        },
-        "node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-        },
-        "node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
-            }
+            "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+            "license": "ISC"
         },
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+            "license": "ISC"
         }
     }
 }


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/9 이슈의 인증 기능 구현 요청에 대한 PR입니다.

## Specify version (commit id)
https://github.com/oss2025hnu/reposcore-js/commit/815b84a00d91fd51c651e84dc2133083fb3bb314

## 구현 내용
- 토큰 인증 옵션 추가
  -a ( --api-key) <token> 으로 깃허브 토큰을 인증할 수 있는 옵션을 추가하였습니다.
 해당 옵션으로 토큰을 인증하여 인증 성공 시, 인증 상태로 프로그램을 사용하며, 
옵션 미사용 시 미인증 상태로 프로그램을 사용합니다.

입력된 토큰의 유효 여부도 확인하여 여부에 따라 다음과 같은 메시지를 출력합니다.

**(토큰 입력 없이 사용 시)**
![image](https://github.com/user-attachments/assets/6c21d395-0cc6-4454-ac19-fb2e86ead9d7)

**(유효한 토큰 입력 시)**
![image](https://github.com/user-attachments/assets/524d1ebe-ce63-4cb2-9b92-0a68e2710891)

**(비정상적인 토큰 입력 시)**
![image](https://github.com/user-attachments/assets/fdca1962-0655-40e3-bdb6-f4c29eb88adb)

- README.md 수정
새로운 옵션의 추가에 따라, README.md의 Usage의 Options에 다음과 같은 문구를 추가하였습니다.
```
-a, --api-key <token>, Github Access Token (optional)
```
 