### PR TITLE
[FEAT] generateTable 함수 구현에 대한 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -117,7 +117,6 @@ class RepoAnalyzer {
         const scores = {};
     
         for (const [participant, activities] of this.participants.entries()) {
-           
             const p_fb = activities.pullRequests.bugAndFeat || 0;
             const p_d = activities.pullRequests.doc || 0;
     
@@ -142,12 +141,20 @@ class RepoAnalyzer {
     }
 
     generateTable(scores) {
-        console.log('"generateTable"함수가 아직 구현되지 않았습니다.')
-        /*
-        const table = new Table({ head: ['Participant', 'Score'] });
-        Object.entries(scores).forEach(([name, score]) => table.push([name, score.toFixed(2)]));
+        const table = new Table({
+            head: ['참가자', '점수'],
+            colWidths: [20, 10],
+            style: {head : ['yellow']}
+        });
+
+        const sorted = Object.entries(scores).sort((a,b) => b[1] - a[1]); // 내림차순 정렬
+
+        sorted.forEach(([name, score]) => {
+            table.push([name, score]);
+        });
+        
+        console.log('점수 집계가 완료되었습니다.');
         console.log(table.toString());
-        */
     }
 
     async generateChart(scores) {


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/27 이슈에 대한 PR 입니다.

## Specify version (commit id)
https://github.com/oss2025hnu/reposcore-js/commit/735eff03c48480670ab145930464da25b12935c3

## 구현 내용
calculateScores 함수가 구현이 되면서, 계산된 점수를 표로 나타낼 수 있게 되었습니다.
cil-table3의 공식문서 https://www.npmjs.com/package/cli-table3?activeTab=readme 를 참고하였으며,
@Jass2345 님의 cil-table3 라이브러리를 사용하여 보기좋게 계산표를 출력해달라는 요구에 맞게 
최대한 보기 쉽게 작업하였습니다.

표는 참가자와 점수로 구분되며, 계산된 점수를 내림차순으로 정렬하여 고득점자부터 표시하였습니다.
![image](https://github.com/user-attachments/assets/1ddde135-1e47-4629-b12d-2885d0585a77)

```
점수 집계가 완료되었습니다.
┌────────────────────┬──────────┐
│ 참가자             │ 점수     │
├────────────────────┼──────────┤
│ joon0447           │ 13       │
├────────────────────┼──────────┤
│ KohSeungJae        │ 9        │
├────────────────────┼──────────┤
│ jaewon786          │ 5        │
├────────────────────┼──────────┤
│ kyahnu             │ 0        │
├────────────────────┼──────────┤
│ Jass2345           │ 0        │
├────────────────────┼──────────┤
│ jungsuryeon        │ 0        │
├────────────────────┼──────────┤
│ bym010312          │ 0        │
├────────────────────┼──────────┤
│ JosephStalin0305   │ 0        │
├────────────────────┼──────────┤
│ seoyoomi           │ 0        │
├────────────────────┼──────────┤
│ MING9UCCI          │ 0        │
└────────────────────┴──────────┘
```

