### PR TITLE
[FEAT] generateChart 함수 구현 에 대한 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -148,13 +148,24 @@ class RepoAnalyzer {
         console.log(table.toString());
     }
 
-    async generateChart(scores) {
-        console.log('"generateChart"함수가 아직 구현되지 않았습니다.')
-        /*
-        // Placeholder: Requires a charting library and canvas setup for CLI
-        console.log('Chart generation placeholder');
-        */
+    generateChart(scores) {
+        console.log('\n기여도 차트를 생성합니다...\n');
+    
+        const sorted = Object.entries(scores).sort((a, b) => b[1] - a[1]);
+        const maxNameLength = Math.max(...sorted.map(([name]) => name.length));
+        const maxScore = Math.max(...sorted.map(([_, score]) => score));
+        const barMaxWidth = 40;
+    
+        for (const [name, score] of sorted) {
+            const barLength = Math.round((score / maxScore) * barMaxWidth);
+            const bar = '█'.repeat(barLength);
+            const paddedName = name.padEnd(maxNameLength, ' ');
+            console.log(`${paddedName} | ${bar} ${score}`);
+        }
+    
+        console.log('\n차트 생성이 완료되었습니다.\n');
     }
+    
 }
 
 module.exports = RepoAnalyzer;


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/32 [FEAT] generateChart 함수 구현 에 대한 PR입니다.
Specify version (commit id)
 eea5320c969f7f5f0a62c95286efc1ffc6372985

구현 내용
-  calculateScores 함수와 generateTable함수가 구현 되면서 generateChart함수를 작성할 수 있었습니다.

-  @Sernn0 님이 이슈내용에서 요청한 "ASCII 기반의 바 차트 또는 그래프 형태로 점수를 표현하면 좋을 것 같습니다."에 맞춰서 generateChart 함수를 calculateScores 함수에서 계산된 점수를 바탕으로, 참가자 별 기여도를 ASCII 기반 막대 그래프로 시각화하였습니다.
바는 █ 문자로 구성되며, 점수에 따라 상대적인 길이로 표현됩니다. 이름과 점수를 함께 표시하여 명확성을 높였습니다.

-  그래프도 표와 마찬가지로, 계산된 점수를 내림차순으로 정렬하여 고득점자부터 표시하였습니다.
