### PR TITLE
[FEAT] 다중 저장소 분석 기능 구현.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ npm install
 Usage: index [options]
 
 Options:
-  -a, --api-key <token> Github Access Token (optional)
-  -r, --repo <path>    Repository path (e.g., user/repo)
-  -o, --output <dir>   Output directory (default: "results")
-  -f, --format <type>  Output format (table, chart, both) (default: "both")
-  -h, --help           display help for command
+  -a, --api-key <token>  Github Access Token (optional)
+  -r, --repo <path...>   Repository path (user1/repo1 user2/repo2...)
+  -o, --output <dir>     Output directory (default: "results")
+  -f, --format <type>    Output format (table, chart, both) (default: "both")
+  -h, --help             display help for command
 ```
 
 ## Score Formula

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const RepoAnalyzer = require('./lib/analyzer');
 
 program
     .option('-a, --api-key <token>', 'Github Access Token (optional)')
-    .option('-r, --repo <path...>', 'Repository path (e.g., user/repo)')
+    .option('-r, --repo <path...>', 'Repository path (user1/repo1 user2/repo2...)')
     .option('-o, --output <dir>', 'Output directory', 'results')
     .option('-f, --format <type>', 'Output format (table, chart, both)', 'both');
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const RepoAnalyzer = require('./lib/analyzer');
 
 program
     .option('-a, --api-key <token>', 'Github Access Token (optional)')
-    .option('-r, --repo <path>', 'Repository path (e.g., user/repo)')
+    .option('-r, --repo <path...>', 'Repository path (e.g., user/repo)')
     .option('-o, --output <dir>', 'Output directory', 'results')
     .option('-f, --format <type>', 'Output format (table, chart, both)', 'both');
 

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -3,7 +3,7 @@ const Table = require('cli-table3');
 
 class RepoAnalyzer {
     constructor(repoPath, token) {
-        this.repoPath = repoPath;
+        this.repoPaths = repoPath;
         this.token = token; // 자신의 github token
         this.participants = new Map();
         this.octokit = token ? new Octokit({auth: token}) : new Octokit(); // 토큰이 등록되었을 경우 인증, 안되었을 경우는 비인증 상태로 진행
@@ -31,68 +31,69 @@ class RepoAnalyzer {
 
     async collectPRsAndIssues() {
         console.log('Collecting PRs and issues...');
-
-        const [owner, repo] = this.repoPath.split('/') // 사용자, 저장소 이름 추출
-        let page = 1
-
         // 확인용 카운터, 추후 제거.
         let bugFeatPRcnt = 0, docPRcnt = 0;
         let bugFeatissueCnt = 0, docissueCnt = 0;
-
-        while(true){
-            const {data : response} = await this.octokit.rest.issues.listForRepo({ // 이슈(일반 이슈 + PR) 데이터를 요청.
-                owner, 
-                repo, 
-                state: 'all',
-                per_page: 100,
-                page
-            });
-
-            response.forEach(issue => {
-                if (!this.participants.has(issue.user.login)){ // 존재하지 않는 사용자라면 초기화.
-                    this.participants.set(issue.user.login, {
-                        pullRequests : {bugAndFeat : 0, doc : 0}, 
-                        issues : {bugAndFeat : 0, doc : 0}, 
-                        comments : 0
-                    });
-                }
-
-                if (issue.pull_request !== undefined){  // PR인 경우.
-                    if (issue.pull_request.merged_at !== null) {  // PR이 병합되었는지 확인.
-                        // 라벨에 따른 분류, 라벨은 문서, 기능, 버그 세 종류만 존재하며 한 이슈/PR에 하나의 라벨만 붙는다고 가정. 라벨이 없다면 개수를 추가하지 않음.
-                        if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){  
-                            this.participants.get(issue.user.login).pullRequests.doc += 1
-                            docPRcnt++;
-                        }
-                        else if (issue.labels.length != 0){
-                            this.participants.get(issue.user.login).pullRequests.bugAndFeat += 1
-                            bugFeatPRcnt++;
+        for (const repoPath of this.repoPaths){
+            const [owner, repo] = repoPath.split('/') // 사용자, 저장소 이름 추출
+            let page = 1
+    
+            while(true){
+                const {data : response} = await this.octokit.rest.issues.listForRepo({ // 이슈(일반 이슈 + PR) 데이터를 요청.
+                    owner, 
+                    repo, 
+                    state: 'all',
+                    per_page: 100,
+                    page
+                });
+    
+                response.forEach(issue => {
+                    if (!this.participants.has(issue.user.login)){ // 존재하지 않는 사용자라면 초기화.
+                        this.participants.set(issue.user.login, {
+                            pullRequests : {bugAndFeat : 0, doc : 0}, 
+                            issues : {bugAndFeat : 0, doc : 0}, 
+                            comments : 0
+                        });
+                    }
+    
+                    if (issue.pull_request !== undefined){  // PR인 경우.
+                        if (issue.pull_request.merged_at !== null) {  // PR이 병합되었는지 확인.
+                            // 라벨에 따른 분류, 라벨은 문서, 기능, 버그 세 종류만 존재하며 한 이슈/PR에 하나의 라벨만 붙는다고 가정. 라벨이 없다면 개수를 추가하지 않음.
+                            if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){  
+                                this.participants.get(issue.user.login).pullRequests.doc += 1
+                                docPRcnt++;
+                            }
+                            else if (issue.labels.length != 0){
+                                this.participants.get(issue.user.login).pullRequests.bugAndFeat += 1
+                                bugFeatPRcnt++;
+                            }
                         }
                     }
+                    else { // 이슈인 경우.
+                        if ( // 반려된 이슈들을 제외시킴.
+                            issue.state_reason == 'completed' ||  // 정상적으로 닫힌 이슈.
+                            issue.state_reason == null ||         // 아직 열려있는 이슈는 null로 표시됨.
+                            issue.state_reason == 'reopened'      // 닫혔던 이슈가 다시 열린 경우.
+                        ){
+                            if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){
+                                this.participants.get(issue.user.login).issues.doc += 1
+                                docissueCnt++;
+                            }
+                            else if (issue.labels.length != 0){
+                                this.participants.get(issue.user.login).issues.bugAndFeat += 1
+                                bugFeatissueCnt++;
+                            }
+                        } 
+                    }
+                });
+    
+                if (response.length < 100){ // 마지막 페이지라면 루프를 탈출.
+                    break;
                 }
-                else { // 이슈인 경우.
-                    if ( // 반려된 이슈들을 제외시킴.
-                        issue.state_reason == 'completed' ||  // 정상적으로 닫힌 이슈.
-                        issue.state_reason == null ||         // 아직 열려있는 이슈는 null로 표시됨.
-                        issue.state_reason == 'reopened'      // 닫혔던 이슈가 다시 열린 경우.
-                    ){
-                        if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){
-                            this.participants.get(issue.user.login).issues.doc += 1
-                            docissueCnt++;
-                        }
-                        else if (issue.labels.length != 0){
-                            this.participants.get(issue.user.login).issues.bugAndFeat += 1
-                            bugFeatissueCnt++;
-                        }
-                    } 
-                }
-            });
-
-            if (response.length < 100){ // 마지막 페이지라면 루프를 탈출.
-                break;
+                page++; // 다음 페이지로 넘어감.
             }
-            page++; // 다음 페이지로 넘어감.
         }
+
 
         // 확인용 console.log, 추후 제거.
         


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/18 해당이슈의 다중 저장소 분석 구현에 대한 PR입니다.


**Specify version (commit id).**
1f4d9fa2ef37b20bd6643f928a02c16d6fbf6b1a

**구현내용**
명령줄 인자의 -r 값을 여러 값을 받도록 변경하였고, 공백으로 구분해 입력합니다. 해당 주소들은 `this.repoPaths` 에 저장되며, collectPRsAndIssues 함수에서 `for (const repoPath of this.repoPaths)` 사용해 모든 주소에 대한 데이터 수집을 진행했습니다. 
테스트 결과는 다음과 같습니다. 

`node index.js -r oss2025hnu/reposcore-js`
```
bug and Feat PRs : 7
doc PRs : 4
bug and Feat issues : 12
doc issues : 4
```
`node index.js -r oss2025hnu/reposcore-py`
```
bug and Feat PRs : 16
doc PRs : 74
bug and Feat issues : 26
doc issues : 78
```
`node index.js -r oss2025hnu/reposcore-js oss2025hnu/reposcore-py` 
````
bug and Feat PRs : 23
doc PRs : 78
bug and Feat issues : 38
doc issues : 82
````

두 저장소의 데이터들이 모두 더해진 모습을 보입니다.