### PR TITLE
[FEAT] 저장소 주소 입력의 형식 검사 구현 요청에 대한 PR 

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,12 @@ const options = program.opts();
 (async () => {
     try {
 
+        if (!options.repo) {
+            console.error('Error :  -r (--repo) 옵션을 필수로 사용하여야 합니다. 예) node index.js -r oss2025hnu/reposcore-js');
+            program.help();
+            process.exit(1);
+        }
+
         // Initialize analyzer with repo path
         const analyzer = new RepoAnalyzer(options.repo, options.apiKey);
         await analyzer.validateToken();

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -94,7 +94,11 @@ class RepoAnalyzer {
                 page++; // 다음 페이지로 넘어감.
             }
         }catch(error){
-            throw new Error("레포지토리 주소가 잘못되었습니다.");
+            if (error.status == 404){
+                throw new Error("레포지토리 주소가 잘못되었습니다.");
+            } else{
+                throw new Error("레포지토리 정보를 불러오는 중 오류가 발생했습니다.");
+            }
         }
         
 

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -38,61 +38,65 @@ class RepoAnalyzer {
         // 확인용 카운터, 추후 제거.
         let bugFeatPRcnt = 0, docPRcnt = 0;
         let bugFeatissueCnt = 0, docissueCnt = 0;
-
-        while(true){
-            const {data : response} = await this.octokit.rest.issues.listForRepo({ // 이슈(일반 이슈 + PR) 데이터를 요청.
-                owner, 
-                repo, 
-                state: 'all',
-                per_page: 100,
-                page
-            });
-
-            response.forEach(issue => {
-                if (!this.participants.has(issue.user.login)){ // 존재하지 않는 사용자라면 초기화.
-                    this.participants.set(issue.user.login, {
-                        pullRequests : {bugAndFeat : 0, doc : 0}, 
-                        issues : {bugAndFeat : 0, doc : 0}, 
-                        comments : 0
-                    });
-                }
-
-                if (issue.pull_request !== undefined){  // PR인 경우.
-                    if (issue.pull_request.merged_at !== null) {  // PR이 병합되었는지 확인.
-                        // 라벨에 따른 분류, 라벨은 문서, 기능, 버그 세 종류만 존재하며 한 이슈/PR에 하나의 라벨만 붙는다고 가정. 라벨이 없다면 개수를 추가하지 않음.
-                        if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){  
-                            this.participants.get(issue.user.login).pullRequests.doc += 1
-                            docPRcnt++;
-                        }
-                        else if (issue.labels.length != 0){
-                            this.participants.get(issue.user.login).pullRequests.bugAndFeat += 1
-                            bugFeatPRcnt++;
+        try{
+            while(true){
+                const {data : response} = await this.octokit.rest.issues.listForRepo({ // 이슈(일반 이슈 + PR) 데이터를 요청.
+                    owner, 
+                    repo, 
+                    state: 'all',
+                    per_page: 100,
+                    page
+                });
+    
+                response.forEach(issue => {
+                    if (!this.participants.has(issue.user.login)){ // 존재하지 않는 사용자라면 초기화.
+                        this.participants.set(issue.user.login, {
+                            pullRequests : {bugAndFeat : 0, doc : 0}, 
+                            issues : {bugAndFeat : 0, doc : 0}, 
+                            comments : 0
+                        });
+                    }
+    
+                    if (issue.pull_request !== undefined){  // PR인 경우.
+                        if (issue.pull_request.merged_at !== null) {  // PR이 병합되었는지 확인.
+                            // 라벨에 따른 분류, 라벨은 문서, 기능, 버그 세 종류만 존재하며 한 이슈/PR에 하나의 라벨만 붙는다고 가정. 라벨이 없다면 개수를 추가하지 않음.
+                            if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){  
+                                this.participants.get(issue.user.login).pullRequests.doc += 1
+                                docPRcnt++;
+                            }
+                            else if (issue.labels.length != 0){
+                                this.participants.get(issue.user.login).pullRequests.bugAndFeat += 1
+                                bugFeatPRcnt++;
+                            }
                         }
                     }
+                    else { // 이슈인 경우.
+                        if ( // 반려된 이슈들을 제외시킴.
+                            issue.state_reason == 'completed' ||  // 정상적으로 닫힌 이슈.
+                            issue.state_reason == null ||         // 아직 열려있는 이슈는 null로 표시됨.
+                            issue.state_reason == 'reopened'      // 닫혔던 이슈가 다시 열린 경우.
+                        ){
+                            if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){
+                                this.participants.get(issue.user.login).issues.doc += 1
+                                docissueCnt++;
+                            }
+                            else if (issue.labels.length != 0){
+                                this.participants.get(issue.user.login).issues.bugAndFeat += 1
+                                bugFeatissueCnt++;
+                            }
+                        } 
+                    }
+                });
+    
+                if (response.length < 100){ // 마지막 페이지라면 루프를 탈출.
+                    break;
                 }
-                else { // 이슈인 경우.
-                    if ( // 반려된 이슈들을 제외시킴.
-                        issue.state_reason == 'completed' ||  // 정상적으로 닫힌 이슈.
-                        issue.state_reason == null ||         // 아직 열려있는 이슈는 null로 표시됨.
-                        issue.state_reason == 'reopened'      // 닫혔던 이슈가 다시 열린 경우.
-                    ){
-                        if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){
-                            this.participants.get(issue.user.login).issues.doc += 1
-                            docissueCnt++;
-                        }
-                        else if (issue.labels.length != 0){
-                            this.participants.get(issue.user.login).issues.bugAndFeat += 1
-                            bugFeatissueCnt++;
-                        }
-                    } 
-                }
-            });
-
-            if (response.length < 100){ // 마지막 페이지라면 루프를 탈출.
-                break;
+                page++; // 다음 페이지로 넘어감.
             }
-            page++; // 다음 페이지로 넘어감.
+        }catch(error){
+            throw new Error("레포지토리 주소가 잘못되었습니다.");
         }
+        
 
         // 확인용 console.log, 추후 제거.
         


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/33 이슈의 PR입니다.

## Specify version (commit id)
https://github.com/oss2025hnu/reposcore-js/commit/1f4d9fa2ef37b20bd6643f928a02c16d6fbf6b1a

## 구현 내용
- 잘못된 repo 주소 입력 시 에러문 수정
try-catch 문을 사용하여 입력된 repo의 주소가 잘못 되어 404 오류가 발생 시, repo 주소가 잘못되었다는 에러문을 한글로 수정하여, 사용자들이 더 쉽게 이해할 수 있도록 수정하였습니다.

![image](https://github.com/user-attachments/assets/c900c295-95a6-456d-8e3d-0a1bc0cc9684)

- -r(--repo) 옵션 미입력시 에러문 수정
기존 영문으로 출력되던 에러문을 한글로 수정하여 -r 옵션이 필수임을 명시하고, 자동으로 -h 옵션이 실행되도록 하였습니다.
![image](https://github.com/user-attachments/assets/533db00d-d193-4b19-9243-300863ca6596)
