### PR TITLE
[FEAT] 다중 저장소 분석 구현

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const RepoAnalyzer = require('./lib/analyzer');
 
 program
     .option('-a, --api-key <token>', 'Github Access Token (optional)')
-    .option('-r, --repo <path>', 'Repository path (e.g., user/repo)')
+    .option('-r, --repo <path...>', 'Repository path (e.g., user/repo)')
     .option('-o, --output <dir>', 'Output directory', 'results')
     .option('-f, --format <type>', 'Output format (table, chart, both)', 'both');
 

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -6,7 +6,7 @@ const path = require('path');
 
 class RepoAnalyzer {
     constructor(repoPath, token) {
-        this.repoPath = repoPath;
+        this.repoPaths = repoPath;
         this.token = token; // 자신의 github token
         this.participants = new Map();
         this.octokit = token ? new Octokit({auth: token}) : new Octokit(); // 토큰이 등록되었을 경우 인증, 안되었을 경우는 비인증 상태로 진행
@@ -35,170 +35,198 @@ class RepoAnalyzer {
     async collectPRsAndIssues() {
         console.log('Collecting PRs and issues...');
 
-        const [owner, repo] = this.repoPath.split('/') // 사용자, 저장소 이름 추출
-        let page = 1
+        if (this.repoPaths.length >= 2)
+            this.participants.set('total', new Map()); 
 
-        // 확인용 카운터, 추후 제거.
-        let bugFeatPRcnt = 0, docPRcnt = 0;
-        let bugFeatissueCnt = 0, docissueCnt = 0;
-        try{
-            while(true){
-                const {data : response} = await this.octokit.rest.issues.listForRepo({ // 이슈(일반 이슈 + PR) 데이터를 요청.
-                    owner, 
-                    repo, 
-                    state: 'all',
-                    per_page: 100,
-                    page
-                });
-    
-                response.forEach(issue => {
-                    if (!this.participants.has(issue.user.login)){ // 존재하지 않는 사용자라면 초기화.
-                        this.participants.set(issue.user.login, {
-                            pullRequests : {bugAndFeat : 0, doc : 0}, 
-                            issues : {bugAndFeat : 0, doc : 0}, 
-                            comments : 0
-                        });
-                    }
-    
-                    if (issue.pull_request !== undefined){  // PR인 경우.
-                        if (issue.pull_request.merged_at !== null) {  // PR이 병합되었는지 확인.
-                            // 라벨에 따른 분류, 라벨은 문서, 기능, 버그 세 종류만 존재하며 한 이슈/PR에 하나의 라벨만 붙는다고 가정. 라벨이 없다면 개수를 추가하지 않음.
-                            if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){  
-                                this.participants.get(issue.user.login).pullRequests.doc += 1
-                                docPRcnt++;
-                            }
-                            else if (issue.labels.length != 0){
-                                this.participants.get(issue.user.login).pullRequests.bugAndFeat += 1
-                                bugFeatPRcnt++;
+        let totalMap = this.participants.get('total', {});
+
+        for (const repoPath of this.repoPaths){
+            const [owner, repo] = repoPath.split('/') // 사용자, 저장소 이름 추출
+            
+            // 확인용 카운터, 추후 제거.
+            let bugFeatPRcnt = 0, docPRcnt = 0;
+            let bugFeatissueCnt = 0, docissueCnt = 0;
+
+            this.participants.set(repo, new Map());
+            let repoMap = this.participants.get(repo);
+            let page = 1
+            try{
+                while(true){
+                    const {data : response} = await this.octokit.rest.issues.listForRepo({ // 이슈(일반 이슈 + PR) 데이터를 요청.
+                        owner, 
+                        repo, 
+                        state: 'all',
+                        per_page: 100,
+                        page
+                    });
+                    
+                    
+                    response.forEach(issue => {
+                        if (!repoMap.has(issue.user.login)){ // 존재하지 않는 사용자라면 초기화.
+                            repoMap.set(issue.user.login, {
+                                pullRequests : {bugAndFeat : 0, doc : 0}, 
+                                issues : {bugAndFeat : 0, doc : 0}, 
+                                comments : 0
+                            });
+                        }
+                        
+                        if (this.repoPaths.length >= 2 && !totalMap.has(issue.user.login)){ // 존재하지 않는 사용자라면 초기화.
+                            totalMap.set(issue.user.login, {
+                                pullRequests : {bugAndFeat : 0, doc : 0}, 
+                                issues : {bugAndFeat : 0, doc : 0}, 
+                                comments : 0
+                            });
+                        }
+                        
+
+        
+                        if (issue.pull_request !== undefined){  // PR인 경우.
+                            if (issue.pull_request.merged_at !== null) {  // PR이 병합되었는지 확인.
+                                // 라벨에 따른 분류, 라벨은 문서, 기능, 버그 세 종류만 존재하며 한 이슈/PR에 하나의 라벨만 붙는다고 가정. 라벨이 없다면 개수를 추가하지 않음.
+                                if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){  
+                                    repoMap.get(issue.user.login).pullRequests.doc += 1;
+                                    if (this.repoPaths.length >= 2) totalMap.get(issue.user.login).pullRequests.doc += 1
+                                    docPRcnt++;
+                                }
+                                else if (issue.labels.length != 0){
+                                    repoMap.get(issue.user.login).pullRequests.bugAndFeat += 1
+                                    if (this.repoPaths.length >= 2) totalMap.get(issue.user.login).pullRequests.bugAndFeat += 1
+                                    bugFeatPRcnt++;
+                                }
                             }
                         }
+                        else { // 이슈인 경우.
+                            if ( // 반려된 이슈들을 제외시킴.
+                                issue.state_reason == 'completed' ||  // 정상적으로 닫힌 이슈.
+                                issue.state_reason == null ||         // 아직 열려있는 이슈는 null로 표시됨.
+                                issue.state_reason == 'reopened'      // 닫혔던 이슈가 다시 열린 경우.
+                            ){
+                                if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){
+                                    repoMap.get(issue.user.login).issues.doc += 1
+                                    if (this.repoPaths.length >= 2) totalMap.get(issue.user.login).issues.doc += 1
+                                    docissueCnt++;
+                                }
+                                else if (issue.labels.length != 0){
+                                    repoMap.get(issue.user.login).issues.bugAndFeat += 1
+                                    if (this.repoPaths.length >= 2) totalMap.get(issue.user.login).issues.bugAndFeat += 1
+                                    bugFeatissueCnt++;
+                                }
+                            } 
+                        }
+                    });
+        
+                    if (response.length < 100){ // 마지막 페이지라면 루프를 탈출.
+                        break;
                     }
-                    else { // 이슈인 경우.
-                        if ( // 반려된 이슈들을 제외시킴.
-                            issue.state_reason == 'completed' ||  // 정상적으로 닫힌 이슈.
-                            issue.state_reason == null ||         // 아직 열려있는 이슈는 null로 표시됨.
-                            issue.state_reason == 'reopened'      // 닫혔던 이슈가 다시 열린 경우.
-                        ){
-                            if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){
-                                this.participants.get(issue.user.login).issues.doc += 1
-                                docissueCnt++;
-                            }
-                            else if (issue.labels.length != 0){
-                                this.participants.get(issue.user.login).issues.bugAndFeat += 1
-                                bugFeatissueCnt++;
-                            }
-                        } 
-                    }
-                });
-    
-                if (response.length < 100){ // 마지막 페이지라면 루프를 탈출.
-                    break;
+                    page++; // 다음 페이지로 넘어감.
                 }
-                page++; // 다음 페이지로 넘어감.
+            }catch(error){
+                if (error.status == 404){
+                    throw new Error("레포지토리 주소가 잘못되었습니다.");
+                } else{
+                    throw new Error("레포지토리 정보를 불러오는 중 오류가 발생했습니다.");
+                }
             }
-        }catch(error){
-            if (error.status == 404){
-                throw new Error("레포지토리 주소가 잘못되었습니다.");
-            } else{
-                throw new Error("레포지토리 정보를 불러오는 중 오류가 발생했습니다.");
-            }
+                    // 확인용 console.log, 추후 제거.
+                    console.log(`\n***${repo}***\n`)
+                    console.log(`bug and Feat PRs : ${bugFeatPRcnt}`)
+                    console.log(`doc PRs : ${docPRcnt}`)
+                    console.log(`bug and Feat issues : ${bugFeatissueCnt}`)
+                    console.log(`doc issues : ${docissueCnt}\n`)
         }
-        
-
-        // 확인용 console.log, 추후 제거.
-        
-        console.log('\n***수집한 정보를 출력합니다.***\n')
-        
-        console.log('\n***total***\n')
-        console.log(`bug and Feat PRs : ${bugFeatPRcnt}`)
-        console.log(`doc PRs : ${docPRcnt}`)
-        console.log(`bug and Feat issues : ${bugFeatissueCnt}`)
-        console.log(`doc issues : ${docissueCnt}\n`)
     }
 
     calculateScores() {
-        const scores = {};
-    
-        for (const [participant, activities] of this.participants.entries()) {
-            const p_fb = activities.pullRequests.bugAndFeat || 0;
-            const p_d = activities.pullRequests.doc || 0;
-    
-            const i_fb = activities.issues.bugAndFeat || 0;
-            const i_d = activities.issues.doc || 0;
-    
-            const p_valid = p_fb + Math.min(p_d, 3 * p_fb);
-            const i_valid = Math.min(i_fb + i_d, 4 * p_valid);
-    
-            const p_fb_at = Math.min(p_fb, p_valid);
-            const p_d_at = p_valid - p_fb_at;
-    
-            const i_fb_at = Math.min(i_fb, i_valid);
-            const i_d_at = i_valid - i_fb_at;
-    
-            const S = 3 * p_fb_at + 2 * p_d_at + 2 * i_fb_at + 1 * i_d_at;
-            scores[participant] = S;
-        }
-    
-        return scores;
-    }
-
-    generateTable(scores) {
-        const table = new Table({
-            head: ['참가자', '점수'],
-            colWidths: [20, 10],
-            style: {head : ['yellow']}
-        });
-
-        const sorted = Object.entries(scores).sort((a,b) => b[1] - a[1]); // 내림차순 정렬
-
-        sorted.forEach(([name, score]) => {
-            table.push([name, score]);
-        });
+        const allRepoScores = new Map();
+        this.participants.forEach((repoActivities, repoName) => {
+            allRepoScores.set(repoName, []);
+            for (const [participant, activities] of repoActivities.entries()) {
+                const p_fb = activities.pullRequests.bugAndFeat || 0;
+                const p_d = activities.pullRequests.doc || 0;
         
-        console.log('점수 집계가 완료되었습니다.');
-        console.log(table.toString());
+                const i_fb = activities.issues.bugAndFeat || 0;
+                const i_d = activities.issues.doc || 0;
+        
+                const p_valid = p_fb + Math.min(p_d, 3 * p_fb);
+                const i_valid = Math.min(i_fb + i_d, 4 * p_valid);
+        
+                const p_fb_at = Math.min(p_fb, p_valid);
+                const p_d_at = p_valid - p_fb_at;
+        
+                const i_fb_at = Math.min(i_fb, i_valid);
+                const i_d_at = i_valid - i_fb_at;
+        
+                const S = 3 * p_fb_at + 2 * p_d_at + 2 * i_fb_at + 1 * i_d_at;
+                allRepoScores.get(repoName).push([participant, S]);
+            }
+        });
+
+        allRepoScores.forEach((repoScores, repoName) =>{
+            allRepoScores.set(repoName, repoScores.sort((a, b) => b[1] - a[1]));
+        });
+        return allRepoScores;
     }
 
-    async generateChart(scores, outputDir = '.') {
-        const width = 800; // px
-        const height = 600; // px
-        const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height });
-    
-        const sorted = Object.entries(scores).sort((a, b) => b[1] - a[1]);
-        const labels = sorted.map(([name]) => name);
-        const data = sorted.map(([_, score]) => score);
-    
-        const configuration = {
-            type: 'bar',
-            data: {
-                labels: labels,
-                datasets: [{
-                    label: '점수',
-                    data: data,
-                }]
-            },
-            options: {
-                responsive: false,
-                plugins: {
-                    title: {
-                        display: true,
-                        text: '참가자 기여도 점수'
-                    }
+    generateTable(allRepoScores) {
+        allRepoScores.forEach((repoScores, repoName) => {
+            const table = new Table({
+                head: ['참가자', '점수'],
+                colWidths: [20, 10],
+                style: {head : ['yellow']}
+            });
+
+            repoScores.forEach(([name, score]) => {
+                table.push([name, score]);
+            });
+
+            console.log(`${repoName}점수 집계가 완료되었습니다.`);
+            console.log(table.toString());
+        });
+    }
+
+    async generateChart(allRepoScores, outputDir = '.') {
+        for (const [repoName, repoScores] of allRepoScores){
+            const width = 800; // px
+            const height = 600; // px
+            const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height });
+            const labels = repoScores.map(([name]) => name);
+            const data = repoScores.map(([_, score]) => score);
+            const configuration = {
+                type: 'bar',
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        label: '점수',
+                        data: data,
+                    }]
                 },
-                scales: {
-                    y: {
-                        beginAtZero: true
+                options: {
+                    responsive: false,
+                    plugins: {
+                        title: {
+                            display: true,
+                            text: '참가자 기여도 점수'
+                        }
+                    },
+                    scales: {
+                        x: {
+                            ticks: {
+                                autoSkip: false, // 레이블 건너뛰지 않음
+                            }
+                        },
+                        y: {
+                            beginAtZero: true
+                        }
                     }
                 }
-            }
-        };
-    
-        const buffer = await chartJSNodeCanvas.renderToBuffer(configuration);
-        const filePath = path.join(outputDir, 'participation_chart.png');
-        fs.writeFileSync(filePath, buffer);
-        console.log(`차트 이미지가 저장되었습니다: ${filePath}`);
+            };
+
+            const buffer = await chartJSNodeCanvas.renderToBuffer(configuration);
+            const filePath = path.join(outputDir, `${repoName}_chart.png`);
+            fs.writeFileSync(filePath, buffer);
+            console.log(`차트 이미지가 저장되었습니다: ${filePath}`);
+        }
     }
-    
 }
 
 module.exports = RepoAnalyzer;


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/18 해당 이슈의 다중 저장소 분석 구현 요청에 대한 PR입니다. 

Specify version (commit id).
bbec14b953f3fed47040c914af9706b7a76f5551

**구현내용**
명령줄 인자의 -r 값을 여러 값을 받도록 변경하였고, 공백으로 구분해 입력합니다. 해당 주소들은 this.repoPaths 에 저장되며, collectPRsAndIssues 함수에서 for (const repoPath of this.repoPaths) 사용해 모든 주소에 대한 데이터 수집을 진행했습니다.
기존의 하나의 저장소의 데이터만 저장하던 participants의 구조가 다음과 같이 변경되었습니다.

```
{
'total' => 
    	'user1' => { pullRequests: {bugAndFeat : 0, doc : 0}, issues: {bugAndFeat : 0, doc : 0} },
    	'user2' => { pullRequests: {bugAndFeat : 0, doc : 0}, issues: {bugAndFeat : 0, doc : 0} }}
		                                                                                                             	   
'repo1' => {
	user1' => { pullRequests: {bugAndFeat : 0, doc : 0}, issues: {bugAndFeat : 0, doc : 0} },
	user2' => { pullRequests: {bugAndFeat : 0, doc : 0}, issues: {bugAndFeat : 0, doc : 0} }},

'repo2' => {...}
}

```
저장소가 한 개 일시, 'total'은 생성되지 않습니다. 
기존의 calculateScores 함수에서 반환되는 `score` 를 `allRepoScores` 로 변경하였으며, 변경된 구조는 다음과 같습니다.

```
{
'total' => [
    	[ 'user1', 0 ],
    	[ 'user2', 0 ]
]
		                                                                                                             	   
'repo1' => [
        [ 'user1', 0 ],
    	[ 'user2', 0 ]
]

'repo2' => [...]
}
```

변경된 변수의 구조에 따라 이후의 함수들을 변경하였고, 두개 이상의 저장소를 분석시, 저장소 각각의 점수 차트, 테이블과 총 점수의 차트와 테이블을 생성하였습니다.