### PR TITLE
[DOC] gitignore 파일에 score_table.txt 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dist
 .pnp.*
 
 .env
+
+score_table.txt


### PR DESCRIPTION
#65 [DOC] gitignore 파일에 score_table.txt 추가

**Specify version (commit id)**
https://github.com/oss2025hnu/reposcore-js/commit/6d24151e5421196f1a7005907a7572b5c58d9152

**변경내용**
- `.gitignore` 파일에 추적하지 않아야 할 파일을 추가 했습니다.