### PR TITLE
[BUG] --output 디랙토리가 생성되지 않은 경우 차트 이미지 생성에 실패함에 대한 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -217,6 +217,13 @@ class RepoAnalyzer {
                 }
             }
         };
+
+        // output 폴더가 생성되어 있는지 확인
+        // 없을 경우 폴더를 생성합니다.
+        if(!fs.existsSync(outputDir)){
+            fs.mkdirSync(outputDir, {recursive: true});
+            console.log(`차트 저장 폴더가 생성되었습니다. ${outputDir}`);
+        }
     
         const buffer = await chartJSNodeCanvas.renderToBuffer(configuration);
         const filePath = path.join(outputDir, 'participation_chart.png');


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/64 이슈에 대한 PR입니다.

## Specify version (commit id)
https://github.com/oss2025hnu/reposcore-js/commit/6d24151e5421196f1a7005907a7572b5c58d9152

## 변경 내용

generateChart 함수 내에서 차트 이미지를 저장하기 전에 차트 이미지 파일이 저장될 폴더가 있는지 확인합니다.
확인 후 존재하지 않으면, 폴더 생성 후 이미지를 저장하도록 변경하였습니다.