### PR TITLE
[BUG] 점수가 0점으로 계산되는 버그 수정 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -126,10 +126,13 @@ class RepoAnalyzer {
             const i_fb = activities.issues.bugAndFeat || 0;
             const i_d = activities.issues.doc || 0;
             
+            const total_pr = p_fb + p_d;
+            const total_issue = i_fb + i_d;
+
             let S;
 
             //최소 1개의 PR, 1개의 이슈가 있다면 이후부터 기존의 비율 계산
-            if (p_fb >= 1 && (i_fb + i_d) >= 1) {
+            if (p_fb > 0 && total_issue > 0 && (total_pr > 1 || total_issue > 1)) {
                 const p_valid = p_fb + Math.min(p_d, 3 * p_fb);
                 const i_valid = Math.min(i_fb + i_d, 4 * p_valid);
 

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -132,7 +132,10 @@ class RepoAnalyzer {
             let S;
 
             //최소 1개의 PR, 1개의 이슈가 있다면 이후부터 기존의 비율 계산
-            if (p_fb > 0 && total_issue > 0 && (total_pr > 1 || total_issue > 1)) {
+            if (total_pr === 0 || total_issue === 0) {
+                S = 0;
+            }
+            else if (p_fb > 0 && total_issue > 0 && (total_pr > 1 || total_issue > 1)) {
                 const p_valid = p_fb + Math.min(p_d, 3 * p_fb);
                 const i_valid = Math.min(i_fb + i_d, 4 * p_valid);
 

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -125,17 +125,25 @@ class RepoAnalyzer {
     
             const i_fb = activities.issues.bugAndFeat || 0;
             const i_d = activities.issues.doc || 0;
-    
-            const p_valid = p_fb + Math.min(p_d, 3 * p_fb);
-            const i_valid = Math.min(i_fb + i_d, 4 * p_valid);
-    
-            const p_fb_at = Math.min(p_fb, p_valid);
-            const p_d_at = p_valid - p_fb_at;
-    
-            const i_fb_at = Math.min(i_fb, i_valid);
-            const i_d_at = i_valid - i_fb_at;
-    
-            const S = 3 * p_fb_at + 2 * p_d_at + 2 * i_fb_at + 1 * i_d_at;
+            
+            let S;
+
+            //최소 1개의 PR, 1개의 이슈가 있다면 이후부터 기존의 비율 계산
+            if (p_fb >= 1 && (i_fb + i_d) >= 1) {
+                const p_valid = p_fb + Math.min(p_d, 3 * p_fb);
+                const i_valid = Math.min(i_fb + i_d, 4 * p_valid);
+
+                const p_fb_at = Math.min(p_fb, p_valid);
+                const p_d_at = p_valid - p_fb_at;
+
+                const i_fb_at = Math.min(i_fb, i_valid);
+                const i_d_at = i_valid - i_fb_at;
+
+                S = 3 * p_fb_at + 2 * p_d_at + 2 * i_fb_at + 1 * i_d_at;
+            } 
+            else {
+                S = 3 * p_fb + 2 * p_d + 2 * i_fb + 1 * i_d;
+            }
             scores[participant] = S;
         }
     


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/55 [BUG] 점수가 0점으로 계산되는 버그 수정 요청에 대한 PR입니다.

**Version (commit id)**
https://github.com/oss2025hnu/reposcore-js/commit/6d24151e5421196f1a7005907a7572b5c58d9152

**변경사항**
- 많은 학생들이 1개의 PR, 1개의 이슈를 작성했음에도 0점으로 표기되는 버그가 있었습니다.
- 이를 해결하기 위해 최소 기준 이상부터 비율을 적용하는 방식으로 수정하였습니다.
- 최소 기준:  
  - **기능/버그 PR 1개 초과 (`p_fb > 0`)** 
  - **그리고 다음 중 하나 이상**:
    - PR 총합 > 1  
    - 이슈 총합 > 1 
- 하나라도 0개인 경우 0점 처리
- 이 기준은 임의로 지정했기에 교수님의 판단에 의해 변경 될 수 있음.

예시)
| PR 수 | 이슈 수 | 계산 방식 |
|-------|---------|------------|
|0 |100| ❌0점 처리|
|100|0|❌0점 처리|
|1|1| ❌ 비율 미적용|
|2|1| ✅ 비율 적용 |
|2|2| ✅ 비율 적용 |
|1|3| ✅ 비율 적용 |