### PR TITLE
[FEAT] 기여도 비율 추가 에 대한 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -158,31 +158,38 @@ class RepoAnalyzer {
 
     generateTable(scores, text) {
 
+        const totalScore = Object.values(scores).reduce((sum, val) => sum + val, 0); // 전체 점수 합
+    
         const table = new Table({
-            head: ['참가자', '점수'],
-            colWidths: [20, 10],
+            head: ['참가자', '점수', '참여율(%)'], // 헤더에 참여율 추가
+            colWidths: [20, 10, 15],
             style: {head : ['yellow']}
         });
-
-
+    
+    
         const sorted = Object.entries(scores).sort((a,b) => b[1] - a[1]); // 내림차순 정렬
-
+    
         if(text){ // txt 파일 생성 옵션 (-t) 활성화 시 
             const textOutput = sorted
-            .map(([name, score]) => `${name} : ${score}`)
+            .map(([name, score]) => {
+                const rate = totalScore > 0 ? ((score / totalScore) * 100).toFixed(1) : '0.0';
+                return `${name} : ${score} (${rate}%)`;
+            })
             .join('\n');
-
+    
             fs.writeFileSync('score_table.txt', textOutput, 'utf-8');
             console.log('점수 집계 텍스트 파일이 생성되었습니다.');
         }
-
+    
         sorted.forEach(([name, score]) => {
-            table.push([name, score]);
+            const rate = totalScore > 0 ? ((score / totalScore) * 100).toFixed(1) : '0.0'; // 참여율 계산
+            table.push([name, score, `${rate}%`]);
         });
         
         console.log('점수 집계가 완료되었습니다.');
         console.log(table.toString());
     }
+    
 
     async generateChart(scores, outputDir = '.') {
         const width = 800; // px


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/57 [FEAT] 기여도 비율 추가 에 대한 PR입니다.

**Specify version (commit id)**
6d24151e5421196f1a7005907a7572b5c58d9152

**구현내용**
@jaewon786 님이 이슈에 올린 "참여율 = (A의 점수 / 전체 점수 총합) × 100 형식으로 참여율을 구하고 generateTable 함수에서 기여도를 추가 합니다." 에 맞게 generateTable에 참여율을 추가하였습니다.

**참고사항**
-  그래프에도 참여율을 나타내기엔 그래프가 지저분해질 것 같아서 표에만 참여율이 보이도록 만들었습니다.