### PR TITLE
[DOC] gitignore 파일에 results 폴더 추가 PR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dist
 .pnp.*
 
 .env
+
+results/


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/68 [DOC] gitignore 파일에 results 폴더 추가에 대한 PR입니다.

Specify version (commit id)
https://github.com/oss2025hnu/reposcore-js/commit/322aa7d08a42bb770f194d6d46e01d0d176a8fce

변경사항
`.gitignore` 파일 최하단에 `results/` 라인을 추가