### PR TITLE
index.js에서 --format 옵션 값 유효성 검사 PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Usage: index [options]
 
 Options:
   -a, --api-key <token> Github Access Token (optional)
-  -t, --text', 'Save table as text file
-  -r, --repo <path>    Repository path (e.g., user/repo)
-  -o, --output <dir>   Output directory (default: "results")
-  -f, --format <type>  Output format (table, chart, both) (default: "both")
-  -h, --help           display help for command
+  -t, --text            Save table as text file
+  -r, --repo <path...>  Repository path (e.g., user/repo)
+  -o, --output <dir>    Output directory (default: "results")
+  -f, --format <type>   Output format (table, chart, both) (default: "both")
+  -h, --help            display help for command
 ```
 
 ## Score Formula

--- a/index.js
+++ b/index.js
@@ -14,10 +14,16 @@ program
     .option('-t, --text', 'Save table as text file')
     .option('-r, --repo <path...>', 'Repository path (e.g., user/repo)')
     .option('-o, --output <dir>', 'Output directory', 'results')
-    .option('-f, --format <type>', 'Output format (table, chart, both)', 'both');
+    .option('-f, --format <type>', 'Output format (table, chart, both, csv)', 'both');
 
 program.parse(process.argv);
 const options = program.opts();
+
+const validFormats = ['table', 'chart', 'both', 'csv'];
+if (!validFormats.includes(options.format)) {
+  console.error(`Error : Invalid format: "${options.format}"\nValid formats are: ${validFormats.join(', ')}`);
+  process.exit(1);
+}
 
 (async () => {
     try {

--- a/index.js
+++ b/index.js
@@ -14,12 +14,12 @@ program
     .option('-t, --text', 'Save table as text file')
     .option('-r, --repo <path...>', 'Repository path (e.g., user/repo)')
     .option('-o, --output <dir>', 'Output directory', 'results')
-    .option('-f, --format <type>', 'Output format (table, chart, both, csv)', 'both');
+    .option('-f, --format <type>', 'Output format (table, chart, both)', 'both');
 
 program.parse(process.argv);
 const options = program.opts();
 
-const validFormats = ['table', 'chart', 'both', 'csv'];
+const validFormats = ['table', 'chart', 'both'];
 if (!validFormats.includes(options.format)) {
   console.error(`Error : Invalid format: "${options.format}"\nValid formats are: ${validFormats.join(', ')}`);
   process.exit(1);


### PR DESCRIPTION
--format 옵션 값 유효성 검사 기능 추가 https://github.com/oss2025hnu/reposcore-js/issues/87 에 대한 PR 입니다.

**Specify version (commit id).**
06950c75b8edfe5fcd7d0b5aa27d783e3a9b9021

**변경사항**
- CLI에서 --format 옵션으로 입력 가능한 값을 제한하는 유효성 검사 로직을 추가했습니다.
- 허용값은 `table`, `chart`, `both`, `csv` 이며, 해당 값 외의 입력이 들어오면 명확한 에러 메시지를 출력하고 프로그램을 종료합니다.