### PR TITLE
[FEAT] generateCsv 함수 구현

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,12 +68,10 @@ const options = program.opts();
         // Generate outputs based on format
         if (options.format === 'table' || options.format === 'both') {
             analyzer.generateTable(scores, options.text);
+            analyzer.generateCsv(scores, options.output)
         }
         if (options.format === 'chart' || options.format === 'both') {
             await analyzer.generateChart(scores, options.output);
-        }
-        if (options.format === 'csv') {
-            console.log(`CSV 파일이 ${options.output}에 저장하는 기능은 아직 구현되지 않았습니다.`);
         }
 
     } catch (error) {

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -204,7 +204,7 @@ class RepoAnalyzer {
                 colWidths: [20, 10],
                 style: { head: ['yellow'] }
             });
-    
+            
             if (text) { // -t 옵션이 활성화된 경우
                 const textOutput = repoScores
                     .map(([name, score]) => `${name} : ${score}`)
@@ -283,6 +283,24 @@ class RepoAnalyzer {
             fs.writeFileSync(filePath, buffer);
             console.log(`차트 이미지가 저장되었습니다: ${filePath}`);
         }
+    }
+    
+    async generateCsv(allRepoScores, outputDir = '.'){
+        allRepoScores.forEach((repoScores, repoName) => {
+            let csvContent = `name,score\n`
+
+            repoScores.forEach(participants => { // ['사용자', 점수] 의 값을 csvContent에 저장
+                csvContent += `${participants[0]},${participants[1]}\n`
+            })
+
+            if(!fs.existsSync(outputDir)){
+                fs.mkdirSync(outputDir);
+            }
+
+            const filePath = path.join(outputDir, `csv_${repoName}.csv`);
+            fs.writeFileSync(filePath, csvContent);
+            console.log(`csv_${repoName}.csv 생성.`);
+        });
     }
 }
 


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/36 해당이슈의 csv파일을 생성하는 함수 구현에 대한 PR입니다.

Specify version (commit id).
06950c75b8edfe5fcd7d0b5aa27d783e3a9b9021

**구현내용**

--format  값에 table 을 선택시 각 이름과 점수를 담고있는 csv파일을 생성하는 generateCsv 함수를 구현하였습니다.
각 csv 파일은 result 디렉터리에 생성됩니다. 