### PR TITLE
[FIX] 유효하지 않은 토큰을 .env에 저장하지 않도록 개선

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,18 +33,29 @@ const options = program.opts();
         if (options.apiKey) {
             const tokenLine = `GITHUB_TOKEN=${options.apiKey}`;
             let shouldWrite = true;
-
-            if (fs.existsSync(ENV_PATH)) {
-                const envContent = fs.readFileSync(ENV_PATH, 'utf-8');
-                if (envContent.includes('GITHUB_TOKEN=')) {
-                    shouldWrite = false;
-                    console.log('.env 파일에 이미 토큰이 등록되어 있습니다.');
+        
+            // 토큰 유효성 검증
+            const { Octokit } = require('@octokit/rest');
+            const testOctokit = new Octokit({ auth: options.apiKey });
+        
+            try {
+                await testOctokit.rest.users.getAuthenticated();
+                console.log('입력된 토큰이 유효합니다.');
+        
+                if (fs.existsSync(ENV_PATH)) {
+                    const envContent = fs.readFileSync(ENV_PATH, 'utf-8');
+                    if (envContent.includes('GITHUB_TOKEN=')) {
+                        shouldWrite = false;
+                        console.log('.env 파일에 이미 토큰이 등록되어 있습니다.');
+                    }
                 }
-            }
-
-            if (shouldWrite) {
-                fs.appendFileSync(ENV_PATH, `${tokenLine}\n`);
-                console.log('.env 파일에 토큰이 저장되었습니다.');
+        
+                if (shouldWrite) {
+                    fs.appendFileSync(ENV_PATH, `${tokenLine}\n`);
+                    console.log('.env 파일에 토큰이 저장되었습니다.');
+                }
+            } catch (error) {
+                throw new Error('입력된 토큰이 유효하지 않아 프로그램을 종료합니다, 유효한 토큰인지 확인해주세요.');
             }
         }
 

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -20,7 +20,7 @@ class RepoAnalyzer {
         console.log('토큰 인증을 진행합니다...')
         try{
             await this.octokit.rest.users.getAuthenticated();
-            console.log('토큰이 정상적으로 등록되었습니다.');
+            console.log('토큰이 인증에 성공했습니다.');
         }catch(error){
             if(error.status == 401){
                 throw new Error('Github 토큰 인증에 실패하여 프로그램을 종료합니다, 유효한 토큰인지 확인해주세요.');


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/89 유효하지 않은 토큰 값이 env 파일에 저장됩니다 에 대한 PR입니다.

Specify version (commit id).
06950c75b8edfe5fcd7d0b5aa27d783e3a9b9021

## 변경 사항
- 토큰의 값을 환경변수에 저장하기전, 입력된 토큰 값이 유효한 값인지 확인을 한 뒤,
유효한 값이라면 저장을, 유효하지 않은 값이라면 저장을 하지 않고 경고문을 출력 후 프로그램을 종료합니다.