### PR TITLE
[FEAT] generateTable 함수의 txt 파일 생성이 이루어지지 않음에 대한 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -216,7 +216,7 @@ class RepoAnalyzer {
                     fs.mkdirSync(resultsDir);
                 }
     
-                const filePath = path.join(resultsDir, 'score_table.txt');
+                const filePath = path.join(resultsDir, `${repoName}.txt`);
                 fs.writeFileSync(filePath, textOutput, 'utf-8');
                 console.log(`점수 집계 텍스트 파일이 생성되었습니다: ${filePath}`);
             }
@@ -268,7 +268,6 @@ class RepoAnalyzer {
                 }
             };
 
-          
             
             // output 폴더가 생성되어 있는지 확인
             // 없을 경우 폴더를 생성합니다.


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/96 에 대한 PR입니다.

## Specify version (commit id)
https://github.com/oss2025hnu/reposcore-js/commit/06950c75b8edfe5fcd7d0b5aa27d783e3a9b9021

## 변경 내용
-t 옵션을 사용하여 생성되는 텍스트 파일의 파일명을 대상 레포지토리의 이름에 따라 변경되도록 하였습니다.

예 ) reposcore-py 대상 텍스트 파일 -> reposcore-py.txt
      reposcore-js 대상 텍스트 파일 -> reposcore-js.txt