### PR TITLE
README.md의 -t 옵션 오탈자 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Usage: index [options]
 
 Options:
   -a, --api-key <token> Github Access Token (optional)
-  -t, --text', 'Save table as text file
-  -r, --repo <path>    Repository path (e.g., user/repo)
-  -o, --output <dir>   Output directory (default: "results")
-  -f, --format <type>  Output format (table, chart, both) (default: "both")
-  -h, --help           display help for command
+  -t, --text            Save table as text file
+  -r, --repo <path...>  Repository path (e.g., user/repo)
+  -o, --output <dir>    Output directory (default: "results")
+  -f, --format <type>   Output format (table, chart, both) (default: "both")
+  -h, --help            display help for command
 ```
 
 ## Score Formula


### PR DESCRIPTION
[DOC] README.md파일 오탈자 수정 필요 https://github.com/oss2025hnu/reposcore-js/issues/103 에 대한 PR 요청입니다.

**Specify version (commit id).**
416888ced68a93193bd01b4bf21d1f737e098b8f

**변경사항**
README.md 파일의 option 설명 중 -t부분에 대한 오탈자를 양식에 맞게 수정했습니다.