### PR TITLE
Use 'fs/promises' for filesystem operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ const options = program.opts();
 
         // Generate outputs based on format
         if (options.format === 'table' || options.format === 'both') {
-            analyzer.generateTable(scores, options.text);
+            await analyzer.generateTable(scores, options.text);
         }
         if (options.format === 'chart' || options.format === 'both') {
             await analyzer.generateChart(scores, options.output);

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -2,6 +2,7 @@ const { Octokit } = require('@octokit/rest');
 const Table = require('cli-table3');
 const { ChartJSNodeCanvas } = require('chartjs-node-canvas');
 const fs = require('fs');
+const fsPromises = require('fs/promises');
 const path = require('path');
 
 class RepoAnalyzer {
@@ -197,8 +198,8 @@ class RepoAnalyzer {
         });
     }
 
-    generateTable(allRepoScores, text) {
-        allRepoScores.forEach((repoScores, repoName) => {
+    async generateTable(allRepoScores, text) {
+        allRepoScores.forEach(async (repoScores, repoName) => {
             const table = new Table({
                 head: ['참가자', '점수'],
                 colWidths: [20, 10],
@@ -213,11 +214,11 @@ class RepoAnalyzer {
                 // results 디렉토리 경로 설정
                 const resultsDir = path.join(__dirname, '..', 'results');
                 if (!fs.existsSync(resultsDir)) {
-                    fs.mkdirSync(resultsDir);
+                    await fsPromises.mkdir(resultsDir);
                 }
     
                 const filePath = path.join(resultsDir, 'score_table.txt');
-                fs.writeFileSync(filePath, textOutput, 'utf-8');
+                await fsPromises.writeFile(filePath, textOutput, 'utf-8');
                 console.log(`점수 집계 텍스트 파일이 생성되었습니다: ${filePath}`);
             }
     
@@ -231,7 +232,7 @@ class RepoAnalyzer {
     }
 
     async generateChart(allRepoScores, outputDir = '.') {
-        for (const [repoName, repoScores] of allRepoScores){
+        allRepoScores.forEach(async (repoScores, repoName) => {
             const width = 800; // px
             const height = 600; // px
             const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height });
@@ -273,16 +274,16 @@ class RepoAnalyzer {
             // output 폴더가 생성되어 있는지 확인
             // 없을 경우 폴더를 생성합니다.
             if(!fs.existsSync(outputDir)){
-                fs.mkdirSync(outputDir, {recursive: true});
+                await fsPromises.mkdir(outputDir, {recursive: true});
                 console.log(`차트 저장 폴더가 생성되었습니다. ${outputDir}`);
             }
 
 
             const buffer = await chartJSNodeCanvas.renderToBuffer(configuration);
             const filePath = path.join(outputDir, `${repoName}_chart.png`);
-            fs.writeFileSync(filePath, buffer);
+            await fsPromises.writeFile(filePath, buffer);
             console.log(`차트 이미지가 저장되었습니다: ${filePath}`);
-        }
+        });
     }
 }
 


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/101

`generateChart()` 및 `generateTable()` 에서 파일시스템 입출력 작업 시 existence 체크를 제외하고 'fs/promises'를 통해 비동기로 처리하도록 개선함.
