### PR TITLE
[BUG] 실행 후 출력되는 .png의 글자가 깨짐 및 내용 다 안보임 문제에 대한 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -233,7 +233,9 @@ class RepoAnalyzer {
     async generateChart(allRepoScores, outputDir = '.') {
         for (const [repoName, repoScores] of allRepoScores){
             const width = 800; // px
-            const height = 600; // px
+            const participantCount = repoScores.length;
+            const barHeight = 30;
+            const height = participantCount * barHeight; // px
             const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height });
             const labels = repoScores.map(([name]) => name);
             const data = repoScores.map(([_, score]) => score);
@@ -242,7 +244,7 @@ class RepoAnalyzer {
                 data: {
                     labels: labels,
                     datasets: [{
-                        label: '점수',
+                        label: 'Score',
                         data: data,
                     }]
                 },
@@ -252,7 +254,7 @@ class RepoAnalyzer {
                     plugins: {
                         title: {
                             display: true,
-                            text: '참가자 기여도 점수'
+                            text: 'Contribution Score by Participant'
                         }
                     },
                     scales: {


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/81
[BUG] 실행 후 출력되는 .png의 글자가 깨짐 및 내용 다 안보임 문제에 대한 PR입니다.

Version (commit id)
416888ced68a93193bd01b4bf21d1f737e098b8f

구현 내용
1. 글꼴 깨짐 현상이 있어 영어로 수정하였습니다.
2. 참가자의 수가 늘어나도 차트 높이가 고정되어 있어 chart.png 파일에 반영이 안되는 현상이 있었습니다. 
    참가자 수 당 높이를 지정하여 차트 높이가 늘어나도록 수정하였습니다.