### PR TITLE
[REFACTOR] 사용하지 않는 property 삭제

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -65,16 +65,14 @@ class RepoAnalyzer {
                         if (!repoMap.has(issue.user.login)){ // 존재하지 않는 사용자라면 초기화.
                             repoMap.set(issue.user.login, {
                                 pullRequests : {bugAndFeat : 0, doc : 0}, 
-                                issues : {bugAndFeat : 0, doc : 0}, 
-                                comments : 0
+                                issues : {bugAndFeat : 0, doc : 0}
                             });
                         }
                         
                         if (this.repoPaths.length >= 2 && !totalMap.has(issue.user.login)){ // 존재하지 않는 사용자라면 초기화.
                             totalMap.set(issue.user.login, {
                                 pullRequests : {bugAndFeat : 0, doc : 0}, 
-                                issues : {bugAndFeat : 0, doc : 0}, 
-                                comments : 0
+                                issues : {bugAndFeat : 0, doc : 0}
                             });
                         }
                         


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/116 repoMap, totalMap 에서 사용되지 않는 comments 삭제에 대한 PR입니다

Specify version (commit id).
063a5118651338dfcca14df2e49e9b2502813c77

##
변경사항
- analyzer.js 파일의 collectPRsAndIssues 함수에서 사용하지 않는 comments 프로퍼티 삭제
