### PR TITLE
[FEAT]Unittest 라이브러리 jest도입#168

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,8 @@ if (!validFormats.includes(options.format)) {
   process.exit(1);
 }
 
-(async () => {
+// 기존 실행 로직을 함수로 분리
+async function main() {
     try {
         if (!options.repo) {
             console.error('Error :  -r (--repo) 옵션을 필수로 사용하여야 합니다. 예) node index.js -r oss2025hnu/reposcore-js');
@@ -170,4 +171,18 @@ if (!validFormats.includes(options.format)) {
         console.error(`Error: ${error.message}`);
         process.exit(1);
     }
-})();
+}
+
+// 실행 여부 확인 및 모듈 내보내기 추가
+if (require.main === module) {
+  main(); // 실행 로직 호출
+}
+
+// 테스트를 위한 모듈 내보내기
+module.exports = {
+  jsonToMap,
+  mapToJson,
+  loadCache,
+  saveCache,
+  updateEnvToken,
+};

--- a/package.json
+++ b/package.json
@@ -9,10 +9,15 @@
         "cli-table3": "^0.6.5",
         "commander": "^9.0.0",
         "csv-writer": "^1.6.0",
-        "dotenv": "^16.4.7",
         "yargs": "^17.7.2"
     },
     "scripts": {
-        "clean": "rm -rf results **/*.png *-lock.json"
+        "clean": "rm -rf results **/*.png *-lock.json",
+        "test": "jest"
+    },
+    "devDependencies": {
+        "dotenv": "^16.5.0",
+        "jest": "^29.7.0",
+        "mock-fs": "^5.5.0"
     }
 }


### PR DESCRIPTION
#168[FEAT]Unittest 라이브러리 jest도입

개선 사항
1. 이슈에서 요청한데로 Jest 도입하기 위해 Jest를 프로젝트에 설치하고, package.json에 테스트 스크립트를 추가했습니다:
2. 모든 코드가 한 파일(index.js)에 포함되어 있었으며, Jest로 테스트할 때 CLI 실행 로직이 함께 실행되는 문제가 있어서 
해당 문제를 해결하기 위해서 require.main === module 조건을 추가해 CLI로직과 유틸리티 함수를 분리하여 문제를 해결 하였습니다.
3. 테스트로는 jsonToMap과 mapToJson 변환 테스트 기능과 .env파일에 토큰을 저장하는 것과 업데이트하는 로직의 기능테스트 그 외에도 데이터를 캐싱하고 불러오는 로직까지 테스트 가능합니다.
4. 실제 파일 시스템이나 외부 API 호출을 이용하는 것이 아닌 Mocking을 활용하여 실제 파일을 생성하거나 수정하지 않고, 가상의 파일을 생성하여 테스트를 할 수 있도록 했습니다.
