### PR TITLE
[BUG] chart.png 점수 표시 오류코드 수정.

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -345,9 +345,7 @@ class RepoAnalyzer {
                             beginAtZero: true
                         }
                     }
-                },
-                plugins: [ ChartDataLabels]
-            
+                }
             };
 
         


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/161 두 개 이상의 저장소를 분석할 때 생성되는 차트의 점수가 중앙으로 표기되지 않는 오류를 수정하였습니다. 

**Version (commit id)**
7ad31edadcb80979c801c81ac77611c4c6a56312

**수정내용**

정확한 오류 원인을 찾지 못해 `generateChart` 함수의 `configuration` 값을 하나하나 수정하다 마지막 값인 
`plugins: [ChartDataLabels]`이 원인임을 파악했습니다. `ChartJSNodeCanvas` 객체를 생성할때
`const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height, plugins:{modern: ['chartjs-plugin-datalabels']} });`
이와같이 해당 플러그인을 활성화 중인데, 이미 활성화된 플러그인을 한번 더 활성화하여 문제가 발생한 것으로 보입니다. 
`configuration` 의 `plugins: [ChartDataLabels]`을 삭제해 오류를 수정하였습니다. 
