### PR TITLE
[BUG] -c 캐시데이터 출력 버그 개선 요청 #165 PR

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 require('dotenv').config();
-const { log } = require('./lib/Utill');
 
 const { program } = require('commander');
 const RepoAnalyzer = require('./lib/analyzer');
+const sqlite3 = require('sqlite3').verbose();
 
 const fs = require('fs');
 const path = require('path');
 const ENV_PATH = path.join(__dirname, '.env');
-const CACHE_PATH = path.join(__dirname, 'cache.json');
+const DB_PATH = path.join(__dirname, 'cache.db'); // SQLite 데이터베이스 파일 경로
 
 program
     .option('-a, --api-key <token>', 'Github Access Token (optional)')
@@ -21,40 +21,71 @@ program
 program.parse(process.argv);
 const options = program.opts();
 
-// ------------- JSON ↔ Map 변환 유틸리티 함수 -------------
-function jsonToMap(jsonObj, depth = 0) {
-    if (depth >= 2 || typeof jsonObj !== 'object' || jsonObj === null || Array.isArray(jsonObj)) {
-        return jsonObj;
-    }
-
-    const map = new Map();
-    for (const key of Object.keys(jsonObj)) {
-        map.set(key, jsonToMap(jsonObj[key], depth + 1));
-    }
-    return map;
+// ------------- SQLite 캐시 유틸리티 함수 -------------
+function initializeDatabase() {
+    const db = new sqlite3.Database(DB_PATH);
+    db.serialize(() => {
+        db.run(`
+            CREATE TABLE IF NOT EXISTS cache (
+                repo TEXT PRIMARY KEY,
+                data TEXT
+            )
+        `);
+    });
+    db.close();
 }
 
-function mapToJson(map) {
-    const obj = {};
-    for (const [key, value] of map) {
-        obj[key] = value instanceof Map ? mapToJson(value) : value;
-    }
-    return obj;
+function saveCacheToDB(repo, data) {
+    const db = new sqlite3.Database(DB_PATH);
+    const jsonData = JSON.stringify(data);
+
+    return new Promise((resolve, reject) => {
+        db.run(
+            `INSERT OR REPLACE INTO cache (repo, data) VALUES (?, ?)`,
+            [repo, jsonData],
+            (err) => {
+                if (err) {
+                    console.error('Error saving cache:', err.message);
+                    reject(err);
+                } else {
+                    // 로그 출력 제거 또는 조건부 출력
+                    if (process.env.NODE_ENV !== 'test') {
+                        console.log(`캐시가 저장되었습니다: ${repo}`);
+                    }
+                    resolve();
+                }
+            }
+        );
+        db.close();
+    });
+}
+// 수정된 loadCacheFromDB 함수
+function loadCacheFromDB(repos) {
+    const db = new sqlite3.Database(DB_PATH);
+    const cachedData = new Map();
+
+    return new Promise((resolve, reject) => {
+        db.serialize(() => {
+            repos.forEach((repo) => {
+                db.get(
+                    `SELECT data FROM cache WHERE repo = ?`,
+                    [repo],
+                    (err, row) => {
+                        if (err) {
+                            console.error('Error loading cache:', err.message);
+                            reject(err);
+                        } else if (row) {
+                            cachedData.set(repo, JSON.parse(row.data));
+                        }
+                    }
+                );
+            });
+
+            db.close(() => resolve(cachedData));
+        });
+    });
 }
 // ------------------------------------------------------------
-
-function loadCache() {
-    if (fs.existsSync(CACHE_PATH)) {
-        const data = fs.readFileSync(CACHE_PATH, 'utf-8');
-        return jsonToMap(JSON.parse(data)); // 수정된 jsonToMap 함수 사용
-    }
-    return null;
-}
-
-function saveCache(participantsMap) {
-    const jsonData = mapToJson(participantsMap);
-    fs.writeFileSync(CACHE_PATH, JSON.stringify(jsonData, null, 2));
-}
 
 // .env 업데이트 유틸리티 함수
 function updateEnvToken(token) {
@@ -74,7 +105,7 @@ function updateEnvToken(token) {
                     tokenUpdated = true;
                     return tokenLine;
                 } else {
-                    log('.env 파일에 이미 동일한 토큰이 등록되어 있습니다.');
+                    console.log('.env 파일에 이미 동일한 토큰이 등록되어 있습니다.');
                     return line;
                 }
             }
@@ -83,16 +114,16 @@ function updateEnvToken(token) {
 
         if (hasTokenKey && tokenUpdated) {
             fs.writeFileSync(ENV_PATH, newLines.join('\n'));
-            log('.env 파일의 토큰이 업데이트되었습니다.');
+            console.log('.env 파일의 토큰이 업데이트되었습니다.');
         }
 
         if (!hasTokenKey) {
             fs.appendFileSync(ENV_PATH, `${tokenLine}\n`);
-            log('.env 파일에 토큰이 저장되었습니다.');
+            console.log('.env 파일에 토큰이 저장되었습니다.');
         }
     } else {
         fs.writeFileSync(ENV_PATH, `${tokenLine}\n`);
-        log('.env 파일이 생성되고 토큰이 저장되었습니다.');
+        console.log('.env 파일이 생성되고 토큰이 저장되었습니다.');
     }
 }
 
@@ -110,6 +141,9 @@ async function main() {
             program.help();
         }
 
+        // 데이터베이스 초기화
+        initializeDatabase();
+
         // API 토큰이 입력되었으면 .env에 저장 (이미 있지 않은 경우)
         if (options.apiKey) {
             const { Octokit } = require('@octokit/rest');
@@ -117,7 +151,7 @@ async function main() {
 
             try {
                 await testOctokit.rest.users.getAuthenticated();
-                log('입력된 토큰이 유효합니다.');
+                console.log('입력된 토큰이 유효합니다.');
                 updateEnvToken(options.apiKey);
             } catch (error) {
                 throw new Error('입력된 토큰이 유효하지 않아 프로그램을 종료합니다, 유효한 토큰인지 확인해주세요.');
@@ -131,21 +165,21 @@ async function main() {
         await analyzer.validateToken();
 
         if (options.useCache) {
-            const cached = loadCache();
-            if (cached) {
-                log("캐시 데이터를 불러왔습니다.");
-                analyzer.participants = cached; // 캐시 데이터를 그대로 할당
+            const cachedData = await loadCacheFromDB(options.repo); // 비동기 방식으로 캐시 데이터 로드
+            if (cachedData.size > 0) {
+                console.log("캐시 데이터를 불러왔습니다.");
+                analyzer.participants = cachedData; // 캐시 데이터를 그대로 할당
             } else {
-                log("캐시 파일이 없어 데이터를 새로 수집합니다.");
-                log("Collecting data...");
+                console.log("지정된 리포지토리에 해당하는 캐시 데이터가 없습니다. 데이터를 새로 수집합니다.");
+                console.log("Collecting data...");
                 await analyzer.collectPRsAndIssues();
-                saveCache(analyzer.participants);
+                options.repo.forEach(repo => saveCacheToDB(repo, analyzer.participants.get(repo)));
             }
         } else {
-            log("캐시를 사용하지 않습니다. 데이터를 새로 수집합니다.");
-            log("Collecting data...");
+            console.log("캐시를 사용하지 않습니다. 데이터를 새로 수집합니다.");
+            console.log("Collecting data...");
             await analyzer.collectPRsAndIssues();
-            saveCache(analyzer.participants);
+            options.repo.forEach(repo => saveCacheToDB(repo, analyzer.participants.get(repo)));
         }
 
         // Calculate scores
@@ -155,7 +189,7 @@ async function main() {
         analyzer.calculateAverageScore(scores);
 
         // 디렉토리 생성
-        if(!fs.existsSync(options.output)){
+        if (!fs.existsSync(options.output)) {
             fs.mkdirSync(options.output);
         }
 
@@ -181,9 +215,8 @@ if (require.main === module) {
 
 // 테스트를 위한 모듈 내보내기
 module.exports = {
-  jsonToMap,
-  mapToJson,
-  loadCache,
-  saveCache,
+  initializeDatabase,
+  saveCacheToDB,
+  loadCacheFromDB,
   updateEnvToken,
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "cli-table3": "^0.6.5",
         "commander": "^9.0.0",
         "csv-writer": "^1.6.0",
+        "sqlite3": "^5.1.7",
         "yargs": "^17.7.2"
     },
     "scripts": {

--- a/tests/cache.test.js
+++ b/tests/cache.test.js
@@ -1,0 +1,26 @@
+const { 
+    initializeDatabase,
+    saveCacheToDB,
+    loadCacheFromDB
+  } = require('../index');
+  
+  describe('캐시 관리 기능', () => {
+    const testData = { user1: { prs: 5 }, user2: { issues: 3 } };
+  
+    beforeAll(() => {
+      // 데이터베이스 초기화
+      initializeDatabase();
+    });
+  
+    test('캐시 저장 및 로드', async () => {
+      // 캐시 저장
+      await saveCacheToDB('testRepo', testData);
+  
+      // 캐시 로드 (비동기 처리)
+      const loaded = await loadCacheFromDB(['testRepo']);
+      
+      // 검증: 데이터 구조 확인
+      expect(loaded.get('testRepo').user1.prs).toBe(5);
+      expect(loaded.get('testRepo').user2.issues).toBe(3);
+    });
+  });

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const mockfs = require('mock-fs'); // Mocking 라이브러리
+const { updateEnvToken } = require('../index');
+
+describe('환경 설정 유틸리티', () => {
+  beforeEach(() => {
+    // Mocking: 가상의 파일 시스템 생성
+    mockfs({
+      '.env': 'GITHUB_TOKEN=existing_token', // 초기 상태의 가상 .env 파일
+    });
+  });
+
+  afterEach(() => {
+    // Mocking: 가상의 파일 시스템 복원
+    mockfs.restore();
+  });
+
+  test('토큰 업데이트 기능', () => {
+    // .env 파일에 새로운 토큰 저장
+    updateEnvToken('test_token_123');
+
+    // .env 파일 내용을 읽어와 검증
+    const envContent = fs.readFileSync('.env', 'utf-8');
+    expect(envContent).toContain('GITHUB_TOKEN=test_token_123');
+  });
+
+  test('기존 토큰이 업데이트되는지 확인', () => {
+    // 기존 토큰이 있는 상태에서 새 토큰으로 업데이트
+    updateEnvToken('new_token');
+
+    // .env 파일 내용을 읽어와 검증
+    const envContent = fs.readFileSync('.env', 'utf-8');
+    expect(envContent).toContain('GITHUB_TOKEN=new_token');
+  });
+  
+});
+


### PR DESCRIPTION
[BUG] -c 캐시데이터 출력 버그 개선 요청 #165

개선  사항 
우선 -c 옵션을 이용하여 캐시 데이터를 출력할 때 JS와 PY를 동시에 가져온 적이 한번이라도 있다면 캐시 데이터를 이용한 리포지토리 지정이 안된다는 것을 알았습니다. 해당 이슈를 개선하기 위해 기존에 있던 JSON 파일 기반 캐시 관리 로직을 그대로 이용하여 해결하려 했으나 
캐시 데이터가 제대로 출력이 안되는 이유로 JSON 파일 하나에 모든 캐시 데이터가 저장 되어있는 문제 때문이라고 판단하여 JSON에 캐시 데이터를 저장하는 것이 아닌 SQLite로 테이블에 저장하는 방식으로 개선하게 되었습니다. 

추가적으로 제가 전에 작업한 부분에서 누락된 TESTS파일도 같이 PR합니다.