### PR TITLE
[BUG] 테이블 깨짐 개선 요청 

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -274,8 +274,7 @@ class RepoAnalyzer {
           // 콘솔 출력
           console.log(table.toString()); 
           log(`${repoName} 점수 계산 및 테이블 출력이 완료되었습니다.`); 
-
-      
+          
           // -t 옵션이 있으면 텍스트 파일 저장
           if (text) {
             const resultsDir = path.join(__dirname, '..', 'results');

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -273,7 +273,7 @@ class RepoAnalyzer {
       
           // 콘솔 출력
           console.log(table.toString()); 
-          log(`${repoName} 점수 집계가 완료되었습니다.`); 
+          log(`${repoName} 점수 계산 및 테이블 출력이 완료되었습니다.`); 
 
       
           // -t 옵션이 있으면 텍스트 파일 저장

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -272,8 +272,9 @@ class RepoAnalyzer {
           });
       
           // 콘솔 출력
-          log(`${repoName} 점수 집계가 완료되었습니다.`);
-          log(table.toString());
+          console.log(table.toString()); 
+          log(`${repoName} 점수 집계가 완료되었습니다.`); 
+
       
           // -t 옵션이 있으면 텍스트 파일 저장
           if (text) {


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/195 에 대한 pr입니다.

시간로그에 의해 표 윗부분이 밀리는 현상을 해결했습니다.
또한 완료 메세지 출력을 수정하여 표가 출력되기 전이 아닌 표가 출력되고 나서 완료 메세지가 출력될 수 있도록 위치를 변경해 주었습니다.