### PR TITLE
타임스탬프 UST -> KST로 변경 

### DIFF
--- a/lib/Utill.js
+++ b/lib/Utill.js
@@ -1,6 +1,6 @@
 // log 타임스탬프 추가 로직
 function log(message) {
-    const now = new Date().toISOString().replace('T', ' ').split('.')[0];
+    const now = new Date().toLocaleString('sv-SE', { timeZone: 'Asia/Seoul' }).replace('T', ' ');
     console.log(`[${now}] ${message}`);
 }
 


### PR DESCRIPTION
타임스탬프 UST -> KST로 변경
https://github.com/oss2025hnu/reposcore-js/issues/197 에 대한 PR 요청입니다.

Specify version (commit id).

5f54a6e046875faaaa0c67b85e6242410ea1d948

변경사항

fix: log 함수에서 UTC 대신 Asia/Seoul(KST) 시간 사용하도록 변경