### PR TITLE
[FEAT] node lib/GenerateReadme.js 실행 여부 자동 검증 기능 추가

### DIFF
--- a/.github/workflows/readme_check.yml
+++ b/.github/workflows/readme_check.yml
@@ -1,0 +1,22 @@
+name: README Sync Check
+
+on: [push, pull_request]
+
+jobs:
+  check-readme:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run README sync check
+        run: node scripts/check_readme.js

--- a/README.md
+++ b/README.md
@@ -100,10 +100,9 @@ GitHub Codespaces에서 본 프로젝트를 열면 `npm install`이 자동으로
 
 ### 구성 요소
 
-- `Readme_Template.md`:  
-  README.md의 템플릿 역할을 하며, `{{ Usage }}` 위치에 CLI 옵션 설명이 삽입됩니다.
-- `lib/GenerateReadme.js`:  
-  자동 생성 스크립트. 실행 시 `README.md`를 갱신합니다.
+- `Readme_Template.md` : README.md의 템플릿 역할을 하며, `{{ Usage }}` 위치에 CLI 옵션 설명이 삽입됩니다.
+- `lib/GenerateReadme.js` : 자동 생성 스크립트. 실행 시 `README.md`를 갱신합니다.
+- `scripts/check_readme.js` : 템플릿만 수정하였을 경우를 대비하여 업데이트 되었는지 확인합니다.
 
 ### 사용 방법
 
@@ -112,6 +111,11 @@ node lib/GenerateReadme.js
 ```
 
 - 위 명령을 실행하면 `index.js --help`의 출력 결과가 템플릿에 삽입되고, 최종 결과로 `README.md`가 생성 또는 덮어써집니다.
+
+```bash
+npm run check_readme
+```
+- 위 명령을 실행하면 README.md의 상태가 최신 상태인지 확인합니다.
 
 ### 주의사항
 

--- a/Readme_Template.md
+++ b/Readme_Template.md
@@ -87,10 +87,9 @@ GitHub Codespaces에서 본 프로젝트를 열면 `npm install`이 자동으로
 
 ### 구성 요소
 
-- `Readme_Template.md`:  
-  README.md의 템플릿 역할을 하며, `{{ Usage }}` 위치에 CLI 옵션 설명이 삽입됩니다.
-- `lib/GenerateReadme.js`:  
-  자동 생성 스크립트. 실행 시 `README.md`를 갱신합니다.
+- `Readme_Template.md` : README.md의 템플릿 역할을 하며, `{{ Usage }}` 위치에 CLI 옵션 설명이 삽입됩니다.
+- `lib/GenerateReadme.js` : 자동 생성 스크립트. 실행 시 `README.md`를 갱신합니다.
+- `scripts/check_readme.js` : 템플릿만 수정하였을 경우를 대비하여 업데이트 되었는지 확인합니다.
 
 ### 사용 방법
 
@@ -99,6 +98,11 @@ node lib/GenerateReadme.js
 ```
 
 - 위 명령을 실행하면 `index.js --help`의 출력 결과가 템플릿에 삽입되고, 최종 결과로 `README.md`가 생성 또는 덮어써집니다.
+
+```bash
+npm run check_readme
+```
+- 위 명령을 실행하면 README.md의 상태가 최신 상태인지 확인합니다.
 
 ### 주의사항
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scripts": {
         "clean": "rm -rf results **/*.png *-lock.json",
         "test": "jest",
-        "check-readme": "node scripts/check_readme.js"
+        "check_readme": "node scripts/check_readme.js"
     },
     "devDependencies": {
         "dotenv": "^16.5.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     },
     "scripts": {
         "clean": "rm -rf results **/*.png *-lock.json",
-        "test": "jest"
+        "test": "jest",
+        "check-readme": "node scripts/check_readme.js"
     },
     "devDependencies": {
         "dotenv": "^16.5.0",

--- a/scripts/check_readme.js
+++ b/scripts/check_readme.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+
+const readmePath = path.join(__dirname, '..', 'README.md');
+const backupPath = path.join(__dirname, '..', 'README.backup.md');
+
+try {
+  const original = fs.readFileSync(readmePath, 'utf-8');
+  fs.writeFileSync(backupPath, original);
+
+  execSync('node lib/GenerateReadme.js');
+
+  const regenerated = fs.readFileSync(readmePath, 'utf-8');
+
+  fs.writeFileSync(readmePath, original);
+  fs.unlinkSync(backupPath);
+
+  if (original !== regenerated) {
+    console.error('README.md가 최신 상태가 아닙니다.');
+    console.error('`node lib/GenerateReadme.js` 실행 후 커밋하세요.');
+    process.exit(1);
+  }
+
+  console.log('README.md는 템플릿과 일치합니다.');
+
+} catch (err) {
+  console.error(`오류 발생: ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
**node lib/GenerateReadme.js 실행 여부 자동 검증 기능 추가에 대한 PR입니다.** https://github.com/oss2025hnu/reposcore-js/issues/190

**Specify version (commit id).**
https://github.com/oss2025hnu/reposcore-js/commit/02c833dc6d1dd4a8666b67c564531451f02fde62

**변경사항**
- README.md가 Readme_Template.md와 동기화되어 있는지 자동으로 검사하는 스크립트(scripts/check_readme.js)를 추가했습니다.
- README.md가 최신 상태가 아닐 경우, 에러 메시지를 출력하고 프로세스를 종료하여 CI 파이프라인이 실패 처리되도록 구성하였습니다.
- GitHub Actions(.github/workflows/readme_check.yml)를 추가하여, push 또는 pull_request 시점에 자동으로 이 검사가 실행됩니다.
- package.json에 "check-readme" 명령어를 등록하여, 로컬 환경에서도 간편하게 검사할 수 있도록 했습니다.