### PR TITLE
Use 'fs/promises' for filesystem operations

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -2,7 +2,7 @@ const { Octokit } = require('@octokit/rest');
 const Table = require('cli-table3');
 const { ChartJSNodeCanvas } = require('chartjs-node-canvas');
 const ChartDataLabels = require('chartjs-plugin-datalabels');
-const fs = require('fs');
+const fs = require('fs').promises;
 const path = require('path');
 const { log } = require('./Utill');
 
@@ -291,8 +291,8 @@ class RepoAnalyzer {
         return newAllRepoScores
     }
     
-    generateTable(allRepoScores, text) {
-        allRepoScores.forEach((repoScores, repoName) => {
+    async generateTable(allRepoScores, text) {
+        const promises = Array.from(allRepoScores).map(async ([repoName, repoScores]) => {
           const table = new Table({
             head: ['참가자', 'feat/bug PR 점수', 'doc PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)'],
             colWidths: [20, 16, 12, 16, 12, 10, 11],
@@ -331,14 +331,15 @@ class RepoAnalyzer {
           // -t 옵션이 있으면 텍스트 파일 저장
           if (text) {
             const resultsDir = path.join(__dirname, '..', 'results');
-            if (!fs.existsSync(resultsDir)) {
-              fs.mkdirSync(resultsDir);
-            }
+            await fs.mkdir(resultsDir, { recursive: true });
+
             const filePath = path.join(resultsDir, `${repoName}.txt`);
-            fs.writeFileSync(filePath, textOutput, 'utf-8');
+            await fs.writeFile(filePath, textOutput, 'utf-8');
             log(`점수 집계 텍스트 파일이 생성되었습니다: ${filePath}`);
           }
         });
+
+        await Promise.all(promises);
       }
 
     async generateChart(allRepoScores, outputDir = '.') {
@@ -408,13 +409,13 @@ class RepoAnalyzer {
         
             const buffer = await chartJSNodeCanvas.renderToBuffer(configuration);
             const filePath = path.join(outputDir, `${repoName}_chart.png`);
-            fs.writeFileSync(filePath, buffer);
+            await fs.writeFile(filePath, buffer);
             log(`차트 이미지가 저장되었습니다: ${filePath}`);
         }
     }
     
     async generateCsv(allRepoScores, outputDir = '.'){
-        allRepoScores.forEach((repoScores, repoName) => {
+        const promises = Array.from(allRepoScores).map(async ([repoName, repoScores]) => {
             let csvContent = `name,feat/bug PR,doc PR,feat/bug issue,doc issue,total\n`;
 
             repoScores.forEach(([name, prFeat, prDoc, issueFeat, issueDoc, total]) => {
@@ -422,9 +423,11 @@ class RepoAnalyzer {
               });
 
             const filePath = path.join(outputDir, `csv_${repoName}.csv`);
-            fs.writeFileSync(filePath, csvContent);
+            await fs.writeFile(filePath, csvContent);
             log(`csv_${repoName}.csv 생성.`);
         });
+
+        await Promise.all(promises);
     }
 }
 


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/101

'fs/promises'를 통해 비동기로 처리하도록 개선하였습니다.
커밋 로그 많이 남기지 않으려고 `cherry-pick` 후, `force-push` 했는데, 다음에는 직접 머지 컨플릭트를 해결해야겠습니다...