### PR TITLE
4글자 이상의 한글 이름과, 영문 이름이 제대로 마스킹 처리되지 않음 수정

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -253,18 +253,23 @@ class RepoAnalyzer {
 
                     // 이름 필터링
                     let name = response.name
-                    const koreanRegex = /[가-힣]/;
-                    if (koreanRegex.test(name)){
-                        if (name.length >= 3) {
-                            // 중간 부분의 * 처리
+                    if (name && name.length >= 2) {
+                    const firstChar = name[0];
+                        const lastChar = name[name.length - 1];
+                         if (name.length >= 4) {
+                            // 4글자 이상이면 양 끝 제외하고 * 처리
                             const maskedMiddle = '*'.repeat(name.length - 2);
-                            name = name[0] + maskedMiddle + name[name.length - 1];
+                            name = firstChar + maskedMiddle + lastChar;
                         }
                         else {
-                            name = name[0] + '*';
+                            // 그 외는 첫 글자 + * 처리
+                            name = firstChar + '*';
                         }
+                    } else if (name && name.length === 1) {
+                           name = name + '*';  // 1글자 이름도 처리
+                    } else {
+                           name = '*'; // 비어있거나 null인 경우    
                     }
-                    
                     usersInfo[usersData[0]] = name;
                 }
             }


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/216

Specify version (commit id).

446df42


변경사항: 4글자 이상의 한글이름과 영문이름이 마스킹 되도록 수정.