### PR TITLE
오타 수정 - 사용자 설명 문자열에서 작은따옴표 escape 처리

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Options:
   -o, --output <dir>     Output directory (default: "results")
   -f, --format <type>    Output format (table, chart, both) (default: "both")
   -c, --use-cache        Use previously cached GitHub data
-  -u, --user-name        Display user`s real name
+  -u, --user-name        Display user's real name
   -h, --help             display help for command
 
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ program
     .option('-o, --output <dir>', 'Output directory', 'results')
     .option('-f, --format <type>', 'Output format (table, chart, both)', 'both')
     .option('-c, --use-cache', 'Use previously cached GitHub data')
-    .option('-u, --user-name', 'Display user`s real name')
+    .option('-u, --user-name', 'Display user\'s real name')
 
 program.parse(process.argv);
 const options = program.opts();


### PR DESCRIPTION
Specify version (commit id)
https://github.com/oss2025hnu/reposcore-js/commit/50acb8d5d6b72498a007effb59a52ed8c11136b8

**변경사항**
`.option('-u, --user-name', 'Display user's real name')`로 문자열 내 따옴표 표기 오류 수정
백틱(을 잘못 사용한 부분을 작은따옴표로 올바르게 수정함

커맨드 도움말 출력 시 "user's"가 올바르게 표시되도록 개선됨