### PR TITLE
오타수정 - 잘못된 코드 블록 표기 ('''bash → ```bash) 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ node index.js -r oss2025hnu/reposcore-js
 
 PR전 결과물 - lock.json, result.png.. 등 temp파일들을 삭제하는 코드입니다. 필수적으로 실행 후 PR하시길 바랍니다.
 
-'''bash
+```bash
 npm run clean
-'''
+```
 
 ## Score Formula
 아래는 PR 개수와 이슈 개수의 비율에 따라 점수로 인정가능한 최대 개수를 구하고 각 배점에 따라 최종 점수를 산출하는 공식이다.

--- a/Readme_Template.md
+++ b/Readme_Template.md
@@ -37,9 +37,9 @@ node index.js -r oss2025hnu/reposcore-js
 
 PR전 결과물 - lock.json, result.png.. 등 temp파일들을 삭제하는 코드입니다. 필수적으로 실행 후 PR하시길 바랍니다.
 
-'''bash
+```bash
 npm run clean
-'''
+```
 
 ## Score Formula
 아래는 PR 개수와 이슈 개수의 비율에 따라 점수로 인정가능한 최대 개수를 구하고 각 배점에 따라 최종 점수를 산출하는 공식이다.


### PR DESCRIPTION
Specify version (commit id).
https://github.com/oss2025hnu/reposcore-js/commit/50acb8d5d6b72498a007effb59a52ed8c11136b8

**변경사항**
clean 사용방법에서 코드 블록이 작은따옴표 세 개(`'''`)로 잘못 감싸져 있어 마크다운에서 제대로 렌더링되지 않는 문제가 있었습니다.
- '''bash...''' → \`\`\`bash...\`\`\`로 수정하여 코드 블록이 정상적으로 보이도록 변경했습니다.

