### PR TITLE
[FEAT] GitHub API 남은 요청 횟수 확인 기능 수정

### DIFF
--- a/lib/checkLimit.js
+++ b/lib/checkLimit.js
@@ -1,0 +1,23 @@
+import { Octokit } from '@octokit/rest';
+
+/**
+ * GitHub API 요청 제한 정보를 출력하는 함수
+ * @param {string} apiKey - GitHub Personal Access Token
+ */
+async function getRateLimit(apiKey) {
+  const octokit = new Octokit({
+    auth: apiKey,
+  });
+
+  try {
+    const res = await octokit.request('GET /rate_limit');
+    const core = res.data.rate;
+
+    console.log(`GitHub API 요청 가능 횟수: ${core.remaining} / ${core.limit}`);
+  } catch (error) {
+    console.error('GitHub API 요청에 실패했습니다.');
+    console.error(error.message);
+  }
+}
+
+export default getRateLimit;


### PR DESCRIPTION
[FEAT] GitHub API 남은 요청 횟수 확인 기능 https://github.com/oss2025hnu/reposcore-js/issues/164
필요한 파일만 다시 추려서 작성했습니다.

Specify version (commit id).
30e7d27

변경사항
--check-limit 옵션 등록
checkLimit.js 모듈 추가