### PR TITLE
[BUG] API 횟수 제한 및 문제 발생 시 오류 문구 및 파일 덮어 쓰기 버그

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -141,12 +141,17 @@ class RepoAnalyzer {
                 }
             }catch(error){
                 const status = error?.status;
-                if (status === 404){
+                if (status === 404) {
                     throw new Error("레포지토리 주소가 잘못되었습니다.");
-                }else if(status === undefined){
+                } else if (status === 403 && status == 429 && error.message.includes('API rate limit exceeded')) {
+                    throw new Error("⚠️ GitHub API 사용 횟수 제한에 도달했습니다 ⚠️\n" +
+                        "다음 방법 중 하나를 선택하여 해결할 수 있습니다:\n" +
+                        "1. GitHub 토큰을 사용하여 실행 (-a 옵션 사용)\n" +
+                        "2. 캐시된 데이터 사용 (-c 옵션 사용)\n" +
+                        "3. 잠시 후 다시 시도");
+                } else if (status === undefined) {
                     throw new Error(`알 수 없는 오류 발생 (status 없음): ${error.message}`);
-                } 
-                else{
+                } else {
                     throw new Error(`레포지토리 정보를 불러오는 중 오류가 발생했습니다. 상태 코드: ${status}, 메시지: ${error.message}`);
                 }
             }


### PR DESCRIPTION

#50 

깃허브 API횟수 제한 / 트래픽 문제로는 403, 429 오류가 발생한다고 합니다.
Error 스테이터스가 403, 429일 경우 throw하도록 했습니다.
에러 메세지로는 

⚠️ GitHub API 사용 횟수 제한에 도달했습니다 ⚠️"
"다음 방법 중 하나를 선택하여 해결할 수 있습니다:"
"1. GitHub 토큰을 사용하여 실행 (-a 옵션 사용)"
"2. 캐시된 데이터 사용 (-c 옵션 사용)"
"3. 잠시 후 다시 시도"

을 넣어 두었습니다.