### PR TITLE
[FEAT]단순 오타 수정 PR과 내용 추가/재구성 PR 의 구분 구현

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -31,7 +31,7 @@ const SCORE = {
 function initParticipant(map, login) {
     if (!map.has(login)) {
         map.set(login, {
-            pullRequests: { bugAndFeat: 0, doc: 0 },
+            pullRequests: {bugAndFeat: 0, doc: 0, typo : 0},
             issues: { bugAndFeat: 0, doc: 0 }
         });
     }
@@ -105,6 +105,11 @@ class RepoAnalyzer {
                                 if (issue.labels.length != 0 && issue.labels[0].name == 'documentation'){  
                                     repoMap.get(issue.user.login).pullRequests.doc += 1;
                                     if (this.repoPaths.length >= 2) totalMap.get(issue.user.login).pullRequests.doc += 1
+                                    docPRcnt++;
+                                }
+                                else if (issue.labels.length != 0 && issue.labels[0].name == 'typo'){  
+                                    repoMap.get(issue.user.login).pullRequests.typo += 1;
+                                    if (this.repoPaths.length >= 2) totalMap.get(issue.user.login).pullRequests.typo += 1
                                     docPRcnt++;
                                 }
                                 else if (issue.labels.length != 0){


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/129 해당 이슈에 대한 PR입니다.

Specify version (commit id).
bf17518e70ae9e70c32ca10b4d0c1856c9dbcee3

구현내용
participants를 초기화 하는 과정에서 오타수정에 해당하는 typo를 추가하였습니다.
collectPRsAndIssues함수에서 typo레이블을 구분하는 코드를 추가하였습니다.
