### PR TITLE
[FIX] ESM 환경에서 require 오류 해결 (#251)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 
 import dotenv from 'dotenv';
 import { program } from 'commander';
+import { Octokit } from '@octokit/rest';
 
 import RepoAnalyzer from './lib/analyzer.js';
 import { log } from './lib/Util.js';
@@ -144,7 +145,6 @@ async function main() {
 
         // API 토큰이 입력되었으면 .env에 저장 (이미 있지 않은 경우)
         if (options.apiKey) {
-            const { Octokit } = require('@octokit/rest');
             const testOctokit = new Octokit({ auth: options.apiKey });
 
             try {


### PR DESCRIPTION
## 변경 내용

- ESM 환경(Codespace)에서 발생하는 `require is not defined` 오류 해결
- `require('@octokit/rest')` → `import { Octokit }`로 변경
- 조건문 내부에서의 동적 로딩 제거하고 `import`를 상단으로 이동
- `.env` 자동 저장 및 토큰 유효성 검증 기능 유지

## 테스트

- Codespace에서 `node index.js -r oss2025hnu/reposcore-js -a <토큰>` 실행 시 정상 작동 확인
- `.env` 자동 생성 확인
- 점수 계산, CSV/차트 출력까지 완료됨

## 관련 이슈

- https://github.com/oss2025hnu/reposcore-js/issues/251