### PR TITLE
[FEAT] PR/ISSUE 개수 CSV 생성 기능 추가 (#257)

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,14 +10,7 @@ import { program } from 'commander';
 import { Octokit } from '@octokit/rest';
 
 import RepoAnalyzer from './lib/analyzer.js';
-import {
-    log,
-    jsonToMap,
-    mapToJson,
-    loadCache,
-    saveCache,
-    updateEnvToken
-  } from './lib/Util.js';
+import { log } from './lib/Util.js';
 
 import getRateLimit from './lib/checkLimit.js';
 
@@ -55,6 +48,85 @@ if (!options.repo) {
   console.error('-r (--repo) 옵션은 필수입니다.');
   program.help();
   process.exit(1);
+}
+
+// ------------- JSON ↔ Map 변환 유틸리티 함수 -------------
+function jsonToMap(jsonObj, depth = 0) {
+    if (depth >= 2 || typeof jsonObj !== 'object' || jsonObj === null || Array.isArray(jsonObj)) {
+        return jsonObj;
+    }
+
+    const map = new Map();
+    for (const key of Object.keys(jsonObj)) {
+        map.set(key, jsonToMap(jsonObj[key], depth + 1));
+    }
+    return map;
+}
+
+function mapToJson(map) {
+    const obj = {};
+    for (const [key, value] of map) {
+        obj[key] = value instanceof Map ? mapToJson(value) : value;
+    }
+    return obj;
+}
+// ------------------------------------------------------------
+
+async function loadCache() {
+    try {
+        await fs.access(CACHE_PATH, fs.constants.R_OK);
+        const data = await fs.readFile(CACHE_PATH, 'utf-8');
+        return jsonToMap(JSON.parse(data)); // 수정된 jsonToMap 함수 사용
+    } catch {
+        return null;
+    }
+}
+
+async function saveCache(participantsMap) {
+    const jsonData = mapToJson(participantsMap);
+    await fs.writeFile(CACHE_PATH, JSON.stringify(jsonData, null, 2));
+}
+
+// .env 업데이트 유틸리티 함수
+async function updateEnvToken(token) {
+    const tokenLine = `GITHUB_TOKEN=${token}`;
+
+    try {
+        await fs.access(ENV_PATH, fs.constants.R_OK);
+
+        const envContent = await fs.readFile(ENV_PATH, 'utf-8');
+        const lines = envContent.split('\n');
+        let tokenUpdated = false;
+        let hasTokenKey = false;
+
+        const newLines = lines.map(line => {
+            if (line.startsWith('GITHUB_TOKEN=')) {
+                hasTokenKey = true;
+                const existingToken = line.split('=')[1];
+                if (existingToken !== token) {
+                    tokenUpdated = true;
+                    return tokenLine;
+                } else {
+                    log('.env 파일에 이미 동일한 토큰이 등록되어 있습니다.');
+                    return line;
+                }
+            }
+            return line;
+        });
+
+        if (hasTokenKey && tokenUpdated) {
+            await fs.writeFile(ENV_PATH, newLines.join('\n'));
+            log('.env 파일의 토큰이 업데이트되었습니다.');
+        }
+
+        if (!hasTokenKey) {
+            await fs.writeFile(ENV_PATH, `${tokenLine}\n`);
+            log('.env 파일에 토큰이 저장되었습니다.');
+        }
+    } catch {
+        await fs.writeFile(ENV_PATH, `${tokenLine}\n`);
+        log('.env 파일이 생성되고 토큰이 저장되었습니다.');
+    }
 }
 
 const validFormats = ['text', 'table', 'chart', 'all']; // 수정: both -> all, text 추가

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -32,6 +32,8 @@ const SCORE = {
 
 const EXCLUDE_USERS = ['kyagrd', 'kyahnu'];
 
+const CSV_HEADER = 'name,feat/bug PR,doc PR,typo PR,feat/bug issue,doc issue,total\n';
+
 // 사용자 초기화 함수
 function initParticipant(map, login) {
     if (!map.has(login)) {
@@ -246,7 +248,7 @@ class RepoAnalyzer {
                     participant,
                     p_fb_score,
                     p_d_score,
-                    p_t_score, // 추가: typo PR 점수
+                    p_t_score, // 추가
                     i_fb_score,
                     i_d_score,
                     totalScore
@@ -448,17 +450,51 @@ class RepoAnalyzer {
         }
     }
     
-    async generateCsv(allRepoScores, outputDir = '.'){
-        const promises = Array.from(allRepoScores).map(async ([repoName, repoScores]) => {
-            let csvContent = `name,feat/bug PR,doc PR,typo PR,feat/bug issue,doc issue,total\n`; // 변경: typo PR 열 추가
+    async generateScoreCsv(repoName, repoScores, outputDir) {
+        let csvContent = CSV_HEADER;
+        let totalScore = 0;
 
-            repoScores.forEach(([name, prFeat, prDoc, prTypo, issueFeat, issueDoc, total]) => { // 변경: prTypo 추가
-                csvContent += `${name},${prFeat},${prDoc},${prTypo},${issueFeat},${issueDoc},${total}\n`;
-            });
+        repoScores.forEach(([name, prFeat, prDoc, prTypo, issueFeat, issueDoc, score]) => {
+            csvContent += `${name},${prFeat},${prDoc},${prTypo},${issueFeat},${issueDoc},${score}\n`;
+            totalScore += score;
+        });
 
-            const filePath = path.join(outputDir, `csv_${repoName}.csv`);
+        const filePath = path.join(outputDir, `csv_${repoName}.csv`);
             await fs.writeFile(filePath, csvContent);
             log(`csv_${repoName}.csv 생성.`);
+    }
+
+    async generateCountCsv(repoName, repoActivities, outputDir) {
+        let csvContent = CSV_HEADER;
+        let totalCount = 0;
+
+        for (const [participant, activities] of repoActivities.entries()) {
+            const p_fb = activities.pullRequests.bugAndFeat || 0;
+            const p_d = activities.pullRequests.doc || 0;
+            const p_t = activities.pullRequests.typo || 0;
+            const i_fb = activities.issues.bugAndFeat || 0;
+            const i_d = activities.issues.doc || 0;
+            const count = p_fb + p_d + p_t + i_fb + i_d;
+
+            csvContent += `${participant},${p_fb},${p_d},${p_t},${i_fb},${i_d},${count}\n`;
+            totalCount += count;
+        }
+
+        const filePath = path.join(outputDir, `activity_count_${repoName}.csv`);
+        await fs.writeFile(filePath, csvContent);
+        log(`활동 개수 집계 CSV 파일이 생성되었습니다: ${filePath}`);
+    }
+
+    async generateCsv(allRepoScores, outputDir = '.') {
+        const promises = Array.from(allRepoScores).map(async ([repoName, repoScores]) => {
+            // 점수 CSV 생성
+            await this.generateScoreCsv(repoName, repoScores, outputDir);
+
+            // 활동 개수 CSV 생성
+            const repoActivities = this.participants.get(repoName);
+            if (repoActivities) {
+                await this.generateCountCsv(repoName, repoActivities, outputDir);
+            }
         });
 
         await Promise.all(promises);


### PR DESCRIPTION
## 관련 이슈
- https://github.com/oss2025hnu/reposcore-js/issues/257

## 변경 사항
- CSV 생성 로직을 `generateScoreCsv`와 `generateCountCsv` 메서드로 분리
- 점수 집계와 활동 개수 집계 CSV 파일의 구조 통일

## 상세 내용
1. CSV 생성 로직 분리
   - `generateScoreCsv`: 점수 기반 CSV 생성 (점수 총합 포함)
   - `generateCountCsv`: 활동 개수 기반 CSV 생성 (활동 총합 포함)
   - `generateCsv`: 두 메서드를 조율하는 메인 메서드

2. 코드 개선
   - CSV 헤더 중복 제거를 위한 `CSV_HEADER` 상수 도입