### PR TITLE
[FEAT] 차트 가독형 향상을 위한 흰색 배경 기능 추가 (#260)

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -9,17 +9,17 @@ import Table from 'cli-table3';
 import { log } from './Util.js';
 
 const colorRanges = [
-    [0, 0, 0],          // 0~9: 검은색
-    [60, 60, 60],       // 10~19: 어두운 회색
-    [120, 120, 120],    // 20~29: 중간 회색
-    [180, 180, 180],    // 30~39: 밝은 회색
-    [144, 238, 144],    // 40~49: 연두색
-    [100, 200, 100],    // 50~59: 진한 연두
-    [30, 144, 255],     // 60~69: 청색
-    [65, 105, 225],     // 70~79: 진한 청색
-    [138, 43, 226],     // 80~89: 보라색
-    [186, 85, 211],     // 90~99: 연보라색
-    [255, 0, 0],        // 100: 빨간색
+    [255, 99, 132],    // 0~9: 연한 빨강
+    [255, 159, 64],    // 10~19: 주황
+    [255, 205, 86],    // 20~29: 노랑
+    [75, 192, 192],    // 30~39: 청록
+    [54, 162, 235],    // 40~49: 파랑
+    [153, 102, 255],   // 50~59: 보라
+    [201, 203, 207],   // 60~69: 회색
+    [255, 99, 71],     // 70~79: 토마토
+    [50, 205, 50],     // 80~89: 라임그린
+    [147, 112, 219],   // 90~99: 연보라
+    [220, 20, 60]      // 100: 진한 빨강
 ];
 
 const SCORE = {
@@ -380,7 +380,12 @@ class RepoAnalyzer {
             const participantCount = repoScores.length;
             const barHeight = 30;
             const height = participantCount * barHeight; // px
-            const chartJSNodeCanvas = new ChartJSNodeCanvas({ width, height, plugins:{modern: ['chartjs-plugin-datalabels']} });
+            const chartJSNodeCanvas = new ChartJSNodeCanvas({ 
+                width, 
+                height, 
+                plugins: {modern: ['chartjs-plugin-datalabels']},
+                backgroundColour: 'white' // 캔버스 배경색 설정
+            });
             
             // 점수에 따라 정렬하고 순위를 추가
             const sortedScores = [...repoScores].sort((a, b) => b[6] - a[6]);
@@ -391,12 +396,12 @@ class RepoAnalyzer {
             });
             
             const data = sortedScores.map(array => array[6]); // 변경: totalScore 인덱스 6으로 조정
-            const barColors = data.map(score => {
-                const clamped = Math.max(0, Math.min(score, 100));
-                const index = Math.floor(clamped / 10);
-                const [r, g, b] = colorRanges[index];
-                return `rgb(${r}, ${g}, ${b})`;
-            })
+            const barColors = data.map((score, index) => {
+                if (index === 0) return 'rgb(255, 215, 0)';      // 1등 : 금색
+                if (index === 1) return 'rgb(128, 128, 128)';    // 2등 : 진한 회색
+                if (index === 2) return 'rgb(205, 127, 50)';     // 3등 : 동색
+                return 'rgb(211, 211, 211)';                     // 4등 이하 : 연한 회색
+            });
 
             const now = new Date();
             const dateStr = now.toLocaleString();
@@ -408,7 +413,8 @@ class RepoAnalyzer {
                     datasets: [{
                         label: 'Score',
                         data: data,
-                        backgroundColor : barColors
+                        backgroundColor: barColors,
+                        borderWidth: 0
                     }],
                 },
 
@@ -418,13 +424,18 @@ class RepoAnalyzer {
                     plugins: {
                         title: {
                             display: true,
-                            text: [`Contribution Score by Participant`, `Generated at ${dateStr}`]
+                            text: [`Contribution Score by Participant`, `Generated at ${dateStr}`],
+                            color: '#333',
+                            font: {
+                                size: 16,
+                                weight: 'bold'
+                            }
                         },
                         subtitle: {
                             display: true,
                             text: `Total number of student : ${participantCount}`,
-                            align: 'end', // 우측 정렬
-                            color: '#888',
+                            align: 'end',
+                            color: '#666',
                             font: {
                                 size: 12
                             },
@@ -434,16 +445,35 @@ class RepoAnalyzer {
                             }
                         },
                         datalabels: {
-                            color: '#ffffff',
+                            color: '#333',
+                            font: {
+                                weight: 'bold'
+                            },
+                            anchor: 'end',
+                            align: 'end',
+                            offset: 4
                         }
                     },
                     scales: {
                         x: {
+                            grid: {
+                                color: '#f0f0f0'
+                            },
                             ticks: {
                                 autoSkip: false,
+                                color: '#333'
                             }
                         },
                         y: {
+                            grid: {
+                                display: false
+                            },
+                            ticks: {
+                                color: '#333',
+                                font: {
+                                    weight: 'bold'  
+                                }
+                            },
                             beginAtZero: true
                         }
                     }

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -9,17 +9,17 @@ import Table from 'cli-table3';
 import { log } from './Util.js';
 
 const colorRanges = [
-    [255, 99, 132],    // 0~9: 연한 빨강
-    [255, 159, 64],    // 10~19: 주황
-    [255, 205, 86],    // 20~29: 노랑
-    [75, 192, 192],    // 30~39: 청록
-    [54, 162, 235],    // 40~49: 파랑
-    [153, 102, 255],   // 50~59: 보라
-    [201, 203, 207],   // 60~69: 회색
-    [255, 99, 71],     // 70~79: 토마토
-    [50, 205, 50],     // 80~89: 라임그린
-    [147, 112, 219],   // 90~99: 연보라
-    [220, 20, 60]      // 100: 진한 빨강
+    [0, 0, 0],          // 0~9: 검은색
+    [60, 60, 60],       // 10~19: 어두운 회색
+    [120, 120, 120],    // 20~29: 중간 회색
+    [180, 180, 180],    // 30~39: 밝은 회색
+    [144, 238, 144],    // 40~49: 연두색
+    [100, 200, 100],    // 50~59: 진한 연두
+    [30, 144, 255],     // 60~69: 청색
+    [65, 105, 225],     // 70~79: 진한 청색
+    [138, 43, 226],     // 80~89: 보라색
+    [186, 85, 211],     // 90~99: 연보라색
+    [255, 0, 0],        // 100: 빨간색
 ];
 
 const SCORE = {
@@ -396,11 +396,10 @@ class RepoAnalyzer {
             });
             
             const data = sortedScores.map(array => array[6]); // 변경: totalScore 인덱스 6으로 조정
-            const barColors = data.map((score, index) => {
-                if (index === 0) return 'rgb(255, 215, 0)';      // 1등 : 금색
-                if (index === 1) return 'rgb(128, 128, 128)';    // 2등 : 진한 회색
-                if (index === 2) return 'rgb(205, 127, 50)';     // 3등 : 동색
-                return 'rgb(211, 211, 211)';                     // 4등 이하 : 연한 회색
+            const barColors = data.map(score => {
+                const index = Math.min(Math.floor(score / 10), 10);
+                const [r, g, b] = colorRanges[index];
+                return `rgb(${r}, ${g}, ${b})`;
             });
 
             const now = new Date();
@@ -414,7 +413,7 @@ class RepoAnalyzer {
                         label: 'Score',
                         data: data,
                         backgroundColor: barColors,
-                        borderWidth: 0
+                        borderColor: barColors.map(color => color.replace('rgb', 'rgba').replace(')', ', 0.6)')),
                     }],
                 },
 
@@ -469,10 +468,7 @@ class RepoAnalyzer {
                                 display: false
                             },
                             ticks: {
-                                color: '#333',
-                                font: {
-                                    weight: 'bold'  
-                                }
+                                color: '#333'
                             },
                             beginAtZero: true
                         }


### PR DESCRIPTION
## 관련 이슈
https://github.com/oss2025hnu/reposcore-js/issues/260

## 변경 사항
차트의 가독성을 개선하기 위해 흰색 배경 적용 기능을 추가했습니다

## 테스트 방법
1. 프로그램을 실행하여 차트 생성
2. 생성된 차트에서 다음 사항 확인:
   - 흰색 배경의 차트가 올바르게 생성되는지

## 스크린샷
<img width="454" alt="스크린샷 2025-04-17 오전 4 17 21" src="https://github.com/user-attachments/assets/8c2b2a4d-34ad-4098-a6ff-8610903e2b67" />

