### PR TITLE
[REFACT] 출력 형식 표준화 - 파일명 형식 통일, 로그 메시지 형식 통일

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -493,9 +493,9 @@ class RepoAnalyzer {
             totalScore += score;
         });
 
-        const filePath = path.join(outputDir, `csv_${repoName}.csv`);
-            await fs.writeFile(filePath, csvContent);
-            log(`csv_${repoName}.csv 생성.`);
+        const filePath = path.join(outputDir, `${repoName}_score.csv`);
+        await fs.writeFile(filePath, csvContent);
+        log(`점수 집계 CSV 파일이 생성되었습니다: ${filePath}`);
     }
 
     async generateCountCsv(repoName, repoActivities, outputDir) {
@@ -514,9 +514,9 @@ class RepoAnalyzer {
             totalCount += count;
         }
 
-        const filePath = path.join(outputDir, `activity_count_${repoName}.csv`);
+        const filePath = path.join(outputDir, `${repoName}_count.csv`);
         await fs.writeFile(filePath, csvContent);
-        log(`활동 개수 집계 CSV 파일이 생성되었습니다: ${filePath}`);
+        log(`활동 개수 CSV 파일이 생성되었습니다: ${filePath}`);
     }
 
     async generateCsv(allRepoScores, outputDir = '.') {


### PR DESCRIPTION
## 관련 이슈
https://github.com/oss2025hnu/reposcore-js/issues/275

## 변경 사항
현재 프로젝트의 출력 형식이 일관되지 않아 발생하는 사용자 혼란을 해결하기 위해 다음과 같이 표준화를 진행했습니다:

### 1. 파일명 형식 통일
기존:
- 점수 CSV: `csv_{repoName}.csv`
- 활동 개수 CSV: `activity_count_{repoName}.csv`

변경:
- 점수 CSV: `{repoName}_score.csv`
- 활동 개수 CSV: `{repoName}_count.csv`

### 2. 로그 메시지 형식 통일
- 시간 형식: `[YYYY-MM-DD 오전/오후 HH:MM]`
- 메시지 구조: `[시간] {파일 유형} 파일이 생성되었습니다: {파일 경로}`

예시:
```bash
[2025-04-17 오후 03:30] 점수 집계 CSV 파일이 생성되었습니다: results/reposcore-js_score.csv
[2025-04-17 오후 03:30] 활동 개수 CSV 파일이 생성되었습니다: results/reposcore-js_count.csv
```

## 테스트 방법
1. 프로그램 실행:
```bash
node index.js -r oss2025hnu/reposcore-js
```

2. 확인 사항:
   - `results` 디렉토리에서 생성된 파일명이 새로운 규칙을 따르는지 확인
   - 콘솔에 출력되는 모든 로그 메시지가 통일된 형식을 따르는지 확인
   - 시간 형식이 `[YYYY-MM-DD 오전/오후 HH:MM]` 패턴으로 일관되게 표시되는지 확인

## 기대 효과
- 파일명의 일관성으로 파일의 용도를 직관적으로 이해할 수 있음
- 통일된 로그 메시지 형식으로 생성 상태를 빠르게 확인 가능
- 효율적인 디버깅 및 결과 분석이 가능