### PR TITLE
[REFACTOR] 리포지토리 병렬 처리 구현

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -78,9 +78,10 @@ class RepoAnalyzer {
 
         let totalMap = this.participants.get('total') || {};
 
-        for (const repoPath of this.repoPaths) {
+        // 병렬 처리를 위한 Promises map 생성
+        const repoPromises = this.repoPaths.map(async (repoPath) => {
             const [owner, repo] = repoPath.split('/'); // 사용자, 저장소 이름 추출
-
+            
             // PR, 이슈 통계 확인용 카운터
             let bugFeatPRcnt = 0, docPRcnt = 0;
             let bugFeatissueCnt = 0, docissueCnt = 0;
@@ -148,6 +149,14 @@ class RepoAnalyzer {
                     }
                     page++; // 다음 페이지로 넘어감.
                 }
+                
+                // PR, 이슈 통계 확인용 log
+                log(`\n***${repo}***\n`);
+                log(`bug and Feat PRs : ${bugFeatPRcnt}`);
+                log(`doc PRs : ${docPRcnt}`);
+                log(`bug and Feat issues : ${bugFeatissueCnt}`);
+                log(`doc issues : ${docissueCnt}\n`);
+                
             } catch (error) {
                 const status = error?.status;
                 if (status === 404) {
@@ -164,13 +173,9 @@ class RepoAnalyzer {
                     throw new Error(`레포지토리 정보를 불러오는 중 오류가 발생했습니다. 상태 코드: ${status}, 메시지: ${error.message}`);
                 }
             }
-            // PR, 이슈 통계 확인용 log
-            log(`\n***${repo}***\n`);
-            log(`bug and Feat PRs : ${bugFeatPRcnt}`);
-            log(`doc PRs : ${docPRcnt}`);
-            log(`bug and Feat issues : ${bugFeatissueCnt}`);
-            log(`doc issues : ${docissueCnt}\n`);
-        }
+        });
+
+        await Promise.all(repoPromises);
     }
 
     calculateAverageScore(allRepoScores) {


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/283 해당 이슈에 대한 PR입니다.

Specify version (commit id).
07cbaaf8e855f7f411b8b03ac25f5f556f2e2fba

구현내용
기존 각각의 리포지토리를 순차적으로 처리하던 collectPRsAndIssues 메서드를 병렬처리로 변경하였습니다.

차이를 확인하기 위해 `Util.js` 의 `log` 함수를 잠시 초 단위까지 표기하게 한 후 확인해 보았습니다.

변경 전
```
node index.js -r oss2025hnu/reposcore-js oss2025hnu/reposcore-py oss2025hnu/reposcore-cs
[2025 04 18 오후 06:29:16] [LOG] 캐시를 사용하지 않습니다. 데이터를 새로 수집합니다.

.
.
.

[2025 04 18 오후 06:29:23] [LOG] 차트 이미지가 저장되었습니다: results/reposcore-cs_chart.png

```

변경 후
```
node index.js -r oss2025hnu/reposcore-js oss2025hnu/reposcore-py oss2025hnu/reposcore-cs
[2025 04 18 오후 06:27:28] [LOG] 캐시를 사용하지 않습니다. 데이터를 새로 수집합니다.
.
.
.
.
[2025 04 18 오후 06:27:33] [LOG] 차트 이미지가 저장되었습니다: results/reposcore-cs_chart.png
```

7초 -> 5초 로 처리 시간이 단축되었습니다.
