### PR TITLE
[FEAT] 테마 매니저 기능 구현에 대한 PR

### DIFF
--- a/lib/ThemeManager.js
+++ b/lib/ThemeManager.js
@@ -1,0 +1,191 @@
+import chalk from 'chalk';
+import fs from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// 현재 디렉토리 경로 설정
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const THEMES_FILE_PATH = path.join(__dirname, '..', 'themes.json');
+
+// 기본값으로 사용할 테마 객체
+const DEFAULT_THEME = {
+    colors: {
+        primary: '#007bff',
+        secondary: '#6c757d',
+        background: '#ffffff',
+        text: '#212529'
+    },
+    table: {
+        head: ['yellow'],
+        border: ['gray']
+    },
+    chart: {
+        backgroundColor: '#ffffff',
+        textColor: '#212529',
+        gridColor: '#e9ecef',
+        barColors: [
+            'rgb(0, 0, 0)',          // 0~9: 검은색
+            'rgb(60, 60, 60)',       // 10~19: 어두운 회색
+            'rgb(120, 120, 120)',    // 20~29: 중간 회색
+            'rgb(180, 180, 180)',    // 30~39: 밝은 회색
+            'rgb(144, 238, 144)',    // 40~49: 연두색
+            'rgb(100, 200, 100)',    // 50~59: 진한 연두
+            'rgb(30, 144, 255)',     // 60~69: 청색
+            'rgb(65, 105, 225)',     // 70~79: 진한 청색
+            'rgb(138, 43, 226)',     // 80~89: 보라색
+            'rgb(186, 85, 211)',     // 90~99: 연보라색
+            'rgb(255, 0, 0)'         // 100: 빨간색
+        ]
+    }
+};
+
+// 다크 테마 기본값
+const DARK_THEME = {
+    colors: {
+        primary: '#0d6efd',
+        secondary: '#6c757d',
+        background: '#212529',
+        text: '#f8f9fa'
+    },
+    table: {
+        head: ['cyan'],
+        border: ['gray']
+    },
+    chart: {
+        backgroundColor: '#212529',
+        textColor: '#f8f9fa',
+        gridColor: '#495057',
+        barColors: {
+            first: 'rgb(255, 215, 0)',    // Gold
+            second: 'rgb(192, 192, 192)', // Silver
+            third: 'rgb(205, 127, 50)',   // Bronze
+            others: 'rgb(169, 169, 169)'  // Gray
+        }
+    }
+};
+
+class ThemeManager {
+    constructor() {
+        // 맵 대신 일반 객체 사용
+        this.themes = {
+            'default': DEFAULT_THEME,
+            'dark': DARK_THEME
+        };
+        this.currentTheme = 'default';
+    }
+
+    // 테마 파일에서 저장된 테마 로드
+    async loadThemes() {
+        try {
+            const data = await fs.readFile(THEMES_FILE_PATH, 'utf8');
+            const savedThemes = JSON.parse(data);
+            // 기본 테마와 저장된 테마 병합
+            this.themes = { ...this.themes, ...savedThemes };
+            const customThemeCount = Object.keys(savedThemes).length;
+            if (customThemeCount > 0) {
+                console.log(`테마 파일에서 ${customThemeCount}개의 커스텀 테마를 로드했습니다.`);
+            }
+        } catch (err) {
+            // 파일이 없는 경우 무시
+            if (err.code !== 'ENOENT') {
+                console.error('테마 파일 로드 중 오류:', err.message);
+            }
+        }
+    }
+
+    // 테마 파일에 테마 저장
+    async saveThemes() {
+        try {
+            // 기본 테마는 제외하고 커스텀 테마만 저장
+            const customThemes = { ...this.themes };
+            delete customThemes['default'];
+            delete customThemes['dark'];
+            
+            await fs.writeFile(THEMES_FILE_PATH, JSON.stringify(customThemes, null, 2), 'utf8');
+        } catch (err) {
+            console.error('테마 파일 저장 중 오류:', err.message);
+        }
+    }
+
+    addTheme(name, theme) {
+        // 기본 테마 구조 가져오기
+        const defaultTheme = this.themes['default'];
+        
+        // 새 테마에 누락된 속성은 기본 테마에서 가져와 병합
+        const mergedTheme = {
+            colors: {
+                ...defaultTheme.colors,
+                ...(theme.colors || {})
+            },
+            table: {
+                ...defaultTheme.table,
+                ...(theme.table || {})
+            },
+            chart: {
+                ...defaultTheme.chart,
+                ...(theme.chart || {}),
+                barColors: {
+                    ...defaultTheme.chart.barColors,
+                    ...(theme.chart?.barColors || {})
+                }
+            }
+        };
+        
+        this.themes[name] = mergedTheme;
+        this.saveThemes();
+        return mergedTheme;
+    }
+
+    setTheme(name) {
+        if (this.themes[name]) {
+            this.currentTheme = name;
+            return true;
+        }
+        return false;
+    }
+
+    getCurrentTheme() {
+        return this.themes[this.currentTheme] || this.themes['default'];
+    }
+
+    getAvailableThemes() {
+        return Object.keys(this.themes);
+    }
+
+    applyTableTheme(table) {
+        const theme = this.getCurrentTheme();
+        if (theme && theme.table) {
+            table.style = {
+                head: theme.table.head,
+                border: theme.table.border
+            };
+        }
+    }
+
+    applyChartTheme(chart) {
+        const theme = this.getCurrentTheme();
+        if (theme && theme.chart) {
+            chart.options = {
+                ...chart.options,
+                backgroundColor: theme.chart.backgroundColor,
+                textColor: theme.chart.textColor,
+                gridColor: theme.chart.gridColor,
+                barColors: theme.chart.barColors
+            };
+        }
+    }
+
+    applyTextTheme(text) {
+        try {
+            const theme = this.getCurrentTheme();
+            if (theme && theme.colors && theme.colors.text) {
+                return chalk.hex(theme.colors.text)(text);
+            }
+        } catch (err) {
+            console.error('Error applying text theme:', err);
+        }
+        return text;
+    }
+}
+
+export default ThemeManager; 

--- a/lib/Util.js
+++ b/lib/Util.js
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import chalk from 'chalk';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ENV_PATH = path.join(__dirname, '..', '.env');
@@ -14,6 +15,14 @@ const LOG_LEVELS = {
     ERROR: 4   // 에러
 };
 
+// 현재 활성화된 테마 저장 변수
+let currentTextColor = '#212529'; // 기본 테마 텍스트 색상
+
+// 테마 텍스트 색상 설정 함수
+function setTextColor(color) {
+    currentTextColor = color;
+}
+
 function log(message, level = 'LOG') {
     const now = new Date().toLocaleString('ko-KR', { 
         timeZone: 'Asia/Seoul',
@@ -26,7 +35,10 @@ function log(message, level = 'LOG') {
     }).replace(/\./g, '').replace(/\s+/g, ' ');
     
     const levelPrefix = `[${level.toUpperCase()}]`;
-    console.log(`[${now}] ${levelPrefix} ${message}`);
+    const formattedMessage = `[${now}] ${levelPrefix} ${message}`;
+    
+    // 테마에 따른 텍스트 색상 적용
+    console.log(chalk.hex(currentTextColor)(formattedMessage));
 }
 
 function jsonToMap(jsonObj, depth = 0) {
@@ -108,6 +120,7 @@ async function updateEnvToken(token) {
 export {
     LOG_LEVELS,
     log,
+    setTextColor,
     jsonToMap,
     mapToJson,
     loadCache,

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -6,7 +6,8 @@ import {Octokit} from '@octokit/rest';
 import {ChartJSNodeCanvas} from 'chartjs-node-canvas';
 import Table from 'cli-table3';
 
-import {log} from './Util.js';
+import {log, setTextColor} from './Util.js';
+import ThemeManager from './ThemeManager.js';
 
 const colorRanges = [
     [0, 0, 0],          // 0~9: 검은색
@@ -50,6 +51,7 @@ class RepoAnalyzer {
         this.token = token; // 자신의 github token
         this.participants = new Map();
         this.octokit = token ? new Octokit({auth: token}) : new Octokit(); // 토큰이 등록되었을 경우 인증, 안되었을 경우는 비인증 상태로 진행
+        this.themeManager = new ThemeManager();
     }
 
     async validateToken() { // API 토큰 인증
@@ -317,17 +319,32 @@ class RepoAnalyzer {
 
     async generateTable(allRepoScores, output) {
         const promises = Array.from(allRepoScores).map(async ([repoName, repoScores]) => {
+            let theme = this.themeManager.getCurrentTheme();
+            
+            // 테마 null 체크
+            if (!theme || !theme.table) {
+                console.error('테이블 테마를 불러올 수 없습니다. 기본 설정을 사용합니다.');
+                theme = {
+                    table: {
+                        head: ['yellow'],
+                        border: ['gray']
+                    }
+                };
+            }
+            
             const table = new Table({
-                head: ['참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)'], // 변경: typo PR 점수 열 추가
-                colWidths: [20, 16, 12, 12, 16, 12, 10, 11], // 변경: 열 너비 조정
-                style: { head: ['none'], border: ['none'] },
+                head: ['참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)'],
+                colWidths: [20, 16, 12, 12, 16, 12, 10, 11],
+                style: { 
+                    head: theme.table.head,
+                    border: theme.table.border
+                }
             });
 
             // 리포지토리 전체 합(= 모든 기여자의 totalScore 합)
             const totalScore = repoScores.reduce((sum, row) => sum + row[6], 0); // 변경: totalScore 인덱스 6으로 조정
 
             // 텍스트 파일로 저장하기 위해 문자열 준비
-
             repoScores.forEach(([name, p_fb_score, p_d_score, p_t_score, i_fb_score, i_d_score, total]) => { // 변경: p_t_score 추가
                 const rate = totalScore > 0 ? ((total / totalScore) * 100).toFixed(2) : '0.00';
 
@@ -342,11 +359,18 @@ class RepoAnalyzer {
                     total,
                     `${rate}%`
                 ]);
-
             });
 
             const filePath = path.join(output, `${repoName}.txt`);
-            await fs.writeFile(filePath, table.toString(), 'utf-8');
+            
+            // ANSI 색상 코드를 제거한 텍스트를 저장
+            // 정규식을 사용하여 ANSI 이스케이프 시퀀스 제거
+            const stripAnsi = (str) => {
+                // ANSI 이스케이프 시퀀스 제거 정규식
+                return str.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
+            };
+            
+            await fs.writeFile(filePath, stripAnsi(table.toString()), 'utf-8');
             log(`점수 집계 텍스트 파일이 생성되었습니다: ${filePath}`);
         });
 
@@ -359,11 +383,31 @@ class RepoAnalyzer {
             const participantCount = repoScores.length;
             const barHeight = 30;
             const height = participantCount * barHeight; // px
+            let theme = this.themeManager.getCurrentTheme();
+            
+            // 테마에서 null 체크 추가
+            if (!theme || !theme.chart) {
+                console.error('차트 테마를 불러올 수 없습니다. 기본 설정을 사용합니다.');
+                theme = {
+                    chart: {
+                        backgroundColor: '#ffffff',
+                        textColor: '#212529',
+                        gridColor: '#e9ecef',
+                        barColors: {
+                            first: 'rgb(255, 215, 0)',    // Gold
+                            second: 'rgb(192, 192, 192)', // Silver
+                            third: 'rgb(205, 127, 50)',   // Bronze
+                            others: 'rgb(169, 169, 169)'  // Gray
+                        }
+                    }
+                };
+            }
+            
             const chartJSNodeCanvas = new ChartJSNodeCanvas({
                 width,
                 height,
                 plugins: {modern: ['chartjs-plugin-datalabels']},
-                backgroundColour: 'white' // 캔버스 배경색 설정
+                backgroundColour: theme.chart.backgroundColor
             });
 
             // 점수에 따라 정렬하고 순위를 추가
@@ -375,10 +419,21 @@ class RepoAnalyzer {
             });
 
             const data = sortedScores.map(array => array[6]); // 변경: totalScore 인덱스 6으로 조정
-            const barColors = data.map(score => {
-                const index = Math.min(Math.floor(score / 10), 10);
-                const [r, g, b] = colorRanges[index];
-                return `rgb(${r}, ${g}, ${b})`;
+            const barColors = data.map((score, index) => {
+                // 상위 3명은 특별 색상
+                if (index === 0 && theme.chart.barColors.first) return theme.chart.barColors.first;
+                if (index === 1 && theme.chart.barColors.second) return theme.chart.barColors.second;
+                if (index === 2 && theme.chart.barColors.third) return theme.chart.barColors.third;
+                if (theme.chart.barColors.others) return theme.chart.barColors.others;
+                
+                // 배열 형태의 barColors인 경우 점수에 따라 색상 선택
+                if (Array.isArray(theme.chart.barColors)) {
+                    const colorIndex = Math.min(10, Math.floor(score / 10));
+                    return theme.chart.barColors[colorIndex];
+                }
+                
+                // 기본 색상 반환
+                return 'rgb(169, 169, 169)'; // 기본 회색
             });
 
             const now = new Date();
@@ -392,10 +447,14 @@ class RepoAnalyzer {
                         label: 'Score',
                         data: data,
                         backgroundColor: barColors,
-                        borderColor: barColors.map(color => color.replace('rgb', 'rgba').replace(')', ', 0.6)')),
+                        borderColor: barColors.map(color => {
+                            if (typeof color === 'string' && color.startsWith('rgb')) {
+                                return color.replace('rgb', 'rgba').replace(')', ', 0.6)');
+                            }
+                            return 'rgba(169, 169, 169, 0.6)'; // 기본 회색 테두리
+                        }),
                     }],
                 },
-
                 options: {
                     responsive: false,
                     indexAxis: 'y',
@@ -403,7 +462,7 @@ class RepoAnalyzer {
                         title: {
                             display: true,
                             text: [`Contribution Score by Participant`, `Generated at ${dateStr}`],
-                            color: '#333',
+                            color: theme.chart.textColor,
                             font: {
                                 size: 16,
                                 weight: 'bold'
@@ -413,7 +472,7 @@ class RepoAnalyzer {
                             display: true,
                             text: `Total number of student : ${participantCount}`,
                             align: 'end',
-                            color: '#666',
+                            color: theme.chart.textColor,
                             font: {
                                 size: 12
                             },
@@ -423,7 +482,7 @@ class RepoAnalyzer {
                             }
                         },
                         datalabels: {
-                            color: '#333',
+                            color: theme.chart.textColor,
                             font: {
                                 weight: 'bold'
                             },
@@ -435,11 +494,11 @@ class RepoAnalyzer {
                     scales: {
                         x: {
                             grid: {
-                                color: '#f0f0f0'
+                                color: theme.chart.gridColor
                             },
                             ticks: {
                                 autoSkip: false,
-                                color: '#333'
+                                color: theme.chart.textColor
                             }
                         },
                         y: {
@@ -447,14 +506,14 @@ class RepoAnalyzer {
                                 display: false
                             },
                             ticks: {
-                                color: '#333'
+                                color: theme.chart.textColor
                             },
                             beginAtZero: true
                         }
                     }
+
                 }
             };
-
 
             const buffer = await chartJSNodeCanvas.renderToBuffer(configuration);
             const filePath = path.join(outputDir, `${repoName}_chart.png`);
@@ -511,6 +570,23 @@ class RepoAnalyzer {
         });
 
         await Promise.all(promises);
+    }
+
+    setTheme(themeName) {
+        const result = this.themeManager.setTheme(themeName);
+        if (result) {
+            const theme = this.themeManager.getCurrentTheme();
+            if (theme && theme.colors) {
+                setTextColor(theme.colors.text);
+            } else {
+                console.error(`테마 '${themeName}'의 색상 정보를 불러올 수 없습니다.`);
+            }
+        }
+        return result;
+    }
+
+    log(message) {
+        console.log(this.themeManager.applyTextTheme(message));
     }
 }
 


### PR DESCRIPTION
## 관련 이슈

https://github.com/oss2025hnu/reposcore-js/issues/287

## 주요 변경사항

### 테마 시스템
- ThemeManager 클래스를 통한 테마 관리 구현
- 테마 설정을 JSON 형식으로 저장하고 불러오는 기능
- 다양한 시각적 요소에 대한 스타일 지정 가능

### 내장 테마
- 기본 테마(default): 밝은 배경과 가독성 높은 색상 구성
- 다크 테마(dark): 어두운 배경과 눈의 피로도를 줄이는 색상 구성

### 커스텀 테마 생성 및 적용
- 사용자가 JSON 형식으로 직접 테마를 정의하고 저장할 수 있음
- 차트 색상, 표 스타일, 텍스트 색상 등을 자유롭게 설정 가능
- 한 번 생성한 테마는 themes.json 파일에 저장되어 재사용 가능

## 테스트 방법
다음 명령어로 테스트할 수 있습니다:

1. 기본 실행:
```bash
node index.js -r oss2025hnu/reposcore-js
```
- 내장 다크 테마 적용
```bash
node index.js -r oss2025hnu/reposcore-js --change-theme dark
```

2. 커스텀 테마 생성 및 적용:
```bash
# 새 테마 생성
node index.js -r oss2025hnu/reposcore-js --create-theme '{"name":"vibrantTheme","theme":{"colors":{"primary":"#FF00FF","secondary":"#00FFFF","background":"#1A1A2E","text":"#E94560"},"table":{"head":["cyan"],"border":["magenta"]},"chart":{"backgroundColor":"#1A1A2E","textColor":"#E94560","gridColor":"#4CAF50","barColors":{"first":"#FF9800","second":"#2196F3","third":"#9C27B0","others":"#607D8B"}}}}'

# 생성된 테마 적용
node index.js -r oss2025hnu/reposcore-js --change-theme vibrantTheme
```

3. 내장 다크 테마 적용:
```bash
node index.js -r oss2025hnu/reposcore-js --change-theme dark
```

## 스크린샷
- 기본 테마
<img width="461" alt="스크린샷 2025-04-18 오후 10 10 04" src="https://github.com/user-attachments/assets/dade7a31-063b-466d-88ca-382a3596478e" />

- 다크 테마
<img width="461" alt="스크린샷 2025-04-18 오후 9 24 24" src="https://github.com/user-attachments/assets/8af447cd-07c5-4656-86db-b69e2aa072b7" />

- 커스텀 테마 (본인 취향껏 만드시면 됩니다.)
<img width="468" alt="스크린샷 2025-04-18 오후 10 11 39" src="https://github.com/user-attachments/assets/07ea4edc-d882-4add-905b-b786c2395f66" />


