### PR TITLE
[FEAT] Util.js 로그 레벨별 출력 방식 차별화 기능 구현에 대한 PR

### DIFF
--- a/lib/Util.js
+++ b/lib/Util.js
@@ -15,6 +15,32 @@ const LOG_LEVELS = {
     ERROR: 4   // 에러
 };
 
+// 로그 레벨별 색상 및 스타일 정의
+const LOG_COLORS = {
+    ERROR: {
+        bg: chalk.bgRed,
+        fg: chalk.white,
+        prefix: '🚨 '
+    },
+    WARN: {
+        bg: chalk.bgYellow,
+        fg: chalk.black,
+        prefix: '⚠️ '
+    },
+    INFO: {
+        fg: chalk.green,
+        prefix: 'ℹ️ '
+    },
+    DEBUG: {
+        fg: chalk.cyan,
+        prefix: '🔍 '
+    },
+    LOG: {
+        fg: chalk.white,
+        prefix: '📝 '
+    }
+};
+
 // 현재 활성화된 테마 저장 변수
 let currentTextColor = '#212529'; // 기본 테마 텍스트 색상
 
@@ -23,7 +49,28 @@ function setTextColor(color) {
     currentTextColor = color;
 }
 
+// 로그 메시지 포맷팅 함수
+function formatLogMessage(level, message, timestamp) {
+    const colors = LOG_COLORS[level] || LOG_COLORS.LOG;
+    
+    // ERROR와 WARN은 배경색 사용
+    if (level === 'ERROR' || level === 'WARN') {
+        return `${timestamp} ${colors.bg(colors.fg(`${colors.prefix}[${level}]`))} ${message}`;
+    }
+    
+    // 나머지는 글자색만 사용
+    return `${timestamp} ${colors.fg(`${colors.prefix}[${level}]`)} ${message}`;
+}
+
 function log(message, level = 'LOG') {
+    // 대문자로 변환하여 일관성 유지
+    level = level.toUpperCase();
+    
+    // 유효한 로그 레벨인지 확인
+    if (!LOG_LEVELS.hasOwnProperty(level)) {
+        level = 'LOG';
+    }
+    
     const now = new Date().toLocaleString('ko-KR', { 
         timeZone: 'Asia/Seoul',
         year: 'numeric',
@@ -34,11 +81,11 @@ function log(message, level = 'LOG') {
         hour12: true
     }).replace(/\./g, '').replace(/\s+/g, ' ');
     
-    const levelPrefix = `[${level.toUpperCase()}]`;
-    const formattedMessage = `[${now}] ${levelPrefix} ${message}`;
+    // 테마 색상 적용 대신 로그 레벨별 색상 적용
+    const formattedMessage = formatLogMessage(level, message, `[${now}]`);
+    console.log(formattedMessage);
     
-    // 테마에 따른 텍스트 색상 적용
-    console.log(chalk.hex(currentTextColor)(formattedMessage));
+    return formattedMessage; // 테스트 및 체이닝을 위해 포맷팅된 메시지 반환
 }
 
 function jsonToMap(jsonObj, depth = 0) {


### PR DESCRIPTION
## 관련 이슈

https://github.com/oss2025hnu/reposcore-js/issues/297

## 변경 사항

Util.js의 로그 출력 방식을 차별화하여 로그 메시지를 각 로그 레벨에 따라 다른 형식과 색상으로 출력되도록 설정했습니다.

## 테스트 방법

- 프로젝트를 실행하고 다양한 로그 레벨을 테스트합니다.
```
node -e "import { log } from './lib/Util.js'; log('기본 로그 메시지'); log('디버그 정보입니다', 'DEBUG'); log('일반 정보입니다', 'INFO'); log('경고 메시지입니다', 'WARN'); log('오류가 발생했습니다', 'ERROR');" --input-type=module
```

- 각 로그 레벨이 올바르게 출력되는지 확인합니다.
다음과 같은 결과를 확인할 수 있습니다.
```
[2025 04 19 오전 07:11] 📝 [LOG] 기본 로그 메시지
[2025 04 19 오전 07:11] 🔍 [DEBUG] 디버그 정보입니다
[2025 04 19 오전 07:11] ℹ️ [INFO] 일반 정보입니다
[2025 04 19 오전 07:11] ⚠️ [WARN] 경고 메시지입니다
[2025 04 19 오전 07:11] 🚨 [ERROR] 오류가 발생했습니다
```