### PR TITLE
[BUG] 차트에서 1등의 점수가 막대 너비를 초과하여 잘리는 현상에 대한 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -424,7 +424,12 @@ class RepoAnalyzer {
                 return `${rank}${suffix} ${name}`;
             });
 
-            const data = sortedScores.map(array => array[6]); // 변경: totalScore 인덱스 6으로 조정
+            const data = sortedScores.map(array => array[6]); // totalScore 값들의 배열
+            
+            // 최고 점수를 찾아서 x축 최댓값 설정
+            const maxScore = Math.max(...data);
+            const xAxisMax = maxScore + 20;  // 최고 점수 + 20
+
             const barColors = data.map((score, index) => {
                 // 상위 3명은 특별 색상
                 if (index === 0 && theme.chart.barColors.first) return theme.chart.barColors.first;
@@ -505,7 +510,8 @@ class RepoAnalyzer {
                             ticks: {
                                 autoSkip: false,
                                 color: theme.chart.textColor
-                            }
+                            },
+                            max: xAxisMax  // 동적으로 계산된 최댓값 설정
                         },
                         y: {
                             grid: {


### PR DESCRIPTION
https://github.com/oss2025hnu/reposcore-js/issues/308 이슈에 대한 PR입니다.

## Specific version
https://github.com/oss2025hnu/reposcore-js/commit/2c40dc21933fdc1331d2b519c0768f49a772c5cf

## 수정 내용
생성되는 차트의 막대가 짤리는 현상을 방지하기 위해, x축의 최댓값을 
점수의 최댓값+20 으로 동적으로 설정되도록 수정하였습니다.