### PR TITLE
[FEAT] 기여자 뱃지 시스템 추가

### DIFF
--- a/lib/Util.js
+++ b/lib/Util.js
@@ -61,6 +61,25 @@ function mapToJson(map) {
     return obj;
 }
 
+// 뱃지 추가
+export function getBadge(score) {
+    const levels = [
+      { min: 0, max: 9, emoji: '🌱', title: '새싹' },
+      { min: 10, max: 19, emoji: '🌿', title: '성장중' },
+      { min: 20, max: 29, emoji: '🌳', title: '나무' },
+      { min: 30, max: 39, emoji: '🌲', title: '성숙한 나무' },
+      { min: 40, max: 49, emoji: '🌴', title: '야자나무' },
+      { min: 50, max: 59, emoji: '🎄', title: '크리스마스 트리' },
+      { min: 60, max: 69, emoji: '🌸', title: '꽃' },
+      { min: 70, max: 79, emoji: '🌺', title: '벚꽃' },
+      { min: 80, max: 89, emoji: '🌹', title: '장미' },
+      { min: 90, max: 99, emoji: '🌻', title: '해바라기' },
+      { min: 100, max: Infinity, emoji: '☀️', title: '태양' },
+    ];
+    const badge = levels.find(l => score >= l.min && score <= l.max);
+    return badge ? `${badge.emoji} ${badge.title}` : '';
+  }
+
 async function loadCache() {
     try {
         await fs.access(CACHE_PATH, fs.constants.R_OK);

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -9,6 +9,8 @@ import Table from 'cli-table3';
 import {log, setTextColor} from './Util.js';
 import ThemeManager from './ThemeManager.js';
 
+import { getBadge } from './Util.js';
+
 const colorRanges = [
     [0, 0, 0],          // 0~9: 검은색
     [60, 60, 60],       // 10~19: 어두운 회색
@@ -353,10 +355,12 @@ class RepoAnalyzer {
             // 텍스트 파일로 저장하기 위해 문자열 준비
             repoScores.forEach(([name, p_fb_score, p_d_score, p_t_score, i_fb_score, i_d_score, total]) => { // 변경: p_t_score 추가
                 const rate = totalScore > 0 ? ((total / totalScore) * 100).toFixed(2) : '0.00';
-
+                //뱃지
+                const badge = getBadge(total);
+                const nameWithBadge = `${badge} ${name}`;
                 // CLI에 표시될 테이블 행
                 table.push([
-                    name,
+                    nameWithBadge,
                     p_fb_score,
                     p_d_score,
                     p_t_score, // 추가


### PR DESCRIPTION
[FEAT] 기여자 뱃지 시스템 추가 (https://github.com/oss2025hnu/reposcore-js/issues/286#top)
#286 에 대한 pr요청입니다.

Specify version (commit id).
1fc1cd9

- 기여자의 총점에 따라 점수 구간별 뱃지(이모지 + 칭호)를 표시하는 기능을 추가했습니다.
- 기존 출력 구조는 유지하되, 이름 앞에 뱃지를 붙여 콘솔 및 텍스트 출력에서도 반영됩니다.
- 점수는 총점을 기준으로 11개 구간으로 나뉘며, `lib/util.js`의 getBadge() 함수를 통해 관리됩니다.
- 출력 대상은 generateTable() 내 table.push()에서 `name`을 `badge + name` 형태로 변경하여 적용하였습니다.