### PR TITLE
[REFACTOR] calculateScores() 함수 계산식 리팩토링 요청

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -390,27 +390,37 @@ class RepoAnalyzer {
             }
             
             const table = new Table({
-                head: ['참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)'],
-                colWidths: [20, 16, 12, 12, 16, 12, 10, 11],
+                head: ['순위', '참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)'],
+                colWidths: [8, 20, 16, 12, 12, 16, 12, 10, 11],
                 style: { 
                     head: theme.table.head,
                     border: theme.table.border
                 }
             });
 
+            // 순위 계산
+            const ranks = this._calculateRanks(repoScores);
+            
             // 리포지토리 전체 합(= 모든 기여자의 totalScore 합)
-            const totalScore = repoScores.reduce((sum, row) => sum + row[6], 0); // 변경: totalScore 인덱스 6으로 조정
+            const totalScore = repoScores.reduce((sum, row) => sum + row[6], 0);
+
+            // 점수 기준으로 정렬
+            const sortedScores = [...repoScores].sort((a, b) => b[6] - a[6]);
 
             // 텍스트 파일로 저장하기 위해 문자열 준비
-            repoScores.forEach(([name, p_fb_score, p_d_score, p_t_score, i_fb_score, i_d_score, total]) => { // 변경: p_t_score 추가
+            sortedScores.forEach(([name, p_fb_score, p_d_score, p_t_score, i_fb_score, i_d_score, total]) => {
                 const rate = totalScore > 0 ? ((total / totalScore) * 100).toFixed(2) : '0.00';
+                const rank = ranks[repoScores.findIndex(score => 
+                    score[0] === name && score[6] === total
+                )];
 
                 // CLI에 표시될 테이블 행
                 table.push([
+                    this._getRankSuffix(rank),
                     name,
                     p_fb_score,
                     p_d_score,
-                    p_t_score, // 추가
+                    p_t_score,
                     i_fb_score,
                     i_d_score,
                     total,
@@ -421,11 +431,7 @@ class RepoAnalyzer {
             const filePath = path.join(output, `${repoName}.txt`);
             
             // ANSI 색상 코드를 제거한 텍스트를 저장
-            // 정규식을 사용하여 ANSI 이스케이프 시퀀스 제거
-            const stripAnsi = (str) => {
-                // ANSI 이스케이프 시퀀스 제거 정규식
-                return str.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
-            };
+            const stripAnsi = (str) => str.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
             
             await fs.writeFile(filePath, stripAnsi(table.toString()), 'utf-8');
             log(`점수 집계 텍스트 파일이 생성되었습니다: ${filePath}`);
@@ -434,12 +440,57 @@ class RepoAnalyzer {
         await Promise.all(promises);
     }
 
+    /**
+     * 점수에 따른 순위를 계산하는 함수
+     * @param {Array} scores - 점수 배열
+     * @returns {Array} 순위 배열 (동점자는 같은 순위, 다음 순위는 건너뜀)
+     */
+    _calculateRanks(scores) {
+        // 점수 기준으로 내림차순 정렬된 배열 생성
+        const sortedScores = [...scores].sort((a, b) => b[6] - a[6]);
+        const ranks = new Array(scores.length);
+        
+        let currentRank = 1;
+        let prevScore = null;
+        
+        for (let i = 0; i < sortedScores.length; i++) {
+            const currentScore = sortedScores[i][6];
+            
+            // 이전 점수와 다르면 현재 인덱스 + 1을 순위로 사용
+            if (prevScore !== currentScore) {
+                currentRank = i + 1;
+            }
+            
+            // 원본 배열에서의 인덱스를 찾아 순위 할당
+            const originalIndex = scores.findIndex(score => 
+                score[0] === sortedScores[i][0] && score[6] === currentScore
+            );
+            ranks[originalIndex] = currentRank;
+            
+            prevScore = currentScore;
+        }
+        
+        return ranks;
+    }
+
+    /**
+     * 순위를 문자열로 변환하는 함수
+     * @param {number} rank - 순위
+     * @returns {string} 순위 문자열 (예: "1st", "2nd", "3rd", "4th")
+     */
+    _getRankSuffix(rank) {
+        if (rank === 1) return '1st';
+        if (rank === 2) return '2nd';
+        if (rank === 3) return '3rd';
+        return `${rank}th`;
+    }
+
     async generateChart(allRepoScores, outputDir = '.') {
         for (const [repoName, repoScores] of allRepoScores) {
-            const width = 800; // px
+            const width = 800;
             const participantCount = repoScores.length;
             const barHeight = 30;
-            const height = participantCount * barHeight; // px
+            const height = participantCount * barHeight;
             let theme = this.themeManager.getCurrentTheme();
             
             // 테마에서 null 체크 추가
@@ -467,25 +518,33 @@ class RepoAnalyzer {
                 backgroundColour: theme.chart.backgroundColor
             });
 
+            // 순위 계산
+            const ranks = this._calculateRanks(repoScores);
+            
             // 점수에 따라 정렬하고 순위를 추가
             const sortedScores = [...repoScores].sort((a, b) => b[6] - a[6]);
             const labels = sortedScores.map(([name], index) => {
-                const rank = index + 1;
-                const suffix = rank === 1 ? 'st' : rank === 2 ? 'nd' : rank === 3 ? 'rd' : 'th';
-                return `${rank}${suffix} ${name}`;
+                const rank = ranks[repoScores.findIndex(score => 
+                    score[0] === name && score[6] === sortedScores[index][6]
+                )];
+                return `${this._getRankSuffix(rank)} ${name}`;
             });
 
-            const data = sortedScores.map(array => array[6]); // totalScore 값들의 배열
+            const data = sortedScores.map(array => array[6]);
             
             // 최고 점수를 찾아서 x축 최댓값 설정
             const maxScore = Math.max(...data);
-            const xAxisMax = maxScore + 20;  // 최고 점수 + 20
+            const xAxisMax = maxScore + 20;
 
             const barColors = data.map((score, index) => {
-                // 상위 3명은 특별 색상
-                if (index === 0 && theme.chart.barColors.first) return theme.chart.barColors.first;
-                if (index === 1 && theme.chart.barColors.second) return theme.chart.barColors.second;
-                if (index === 2 && theme.chart.barColors.third) return theme.chart.barColors.third;
+                const rank = ranks[repoScores.findIndex(s => 
+                    s[0] === sortedScores[index][0] && s[6] === score
+                )];
+                
+                // 순위에 따른 색상 지정
+                if (rank === 1 && theme.chart.barColors.first) return theme.chart.barColors.first;
+                if (rank === 2 && theme.chart.barColors.second) return theme.chart.barColors.second;
+                if (rank === 3 && theme.chart.barColors.third) return theme.chart.barColors.third;
                 if (theme.chart.barColors.others) return theme.chart.barColors.others;
                 
                 // 배열 형태의 barColors인 경우 점수에 따라 색상 선택
@@ -494,8 +553,7 @@ class RepoAnalyzer {
                     return theme.chart.barColors[colorIndex];
                 }
                 
-                // 기본 색상 반환
-                return 'rgb(169, 169, 169)'; // 기본 회색
+                return 'rgb(169, 169, 169)';
             });
 
             const now = new Date();
@@ -586,12 +644,20 @@ class RepoAnalyzer {
     }
 
     async generateScoreCsv(repoName, repoScores, outputDir) {
-        let csvContent = CSV_HEADER;
-        let totalScore = 0;
+        // 헤더에 순위 컬럼 추가
+        let csvContent = 'rank,name,feat/bug PR,doc PR,typo PR,feat/bug issue,doc issue,total\n';
+        
+        // 순위 계산
+        const ranks = this._calculateRanks(repoScores);
+        
+        // 점수 기준으로 정렬
+        const sortedScores = [...repoScores].sort((a, b) => b[6] - a[6]);
 
-        repoScores.forEach(([name, prFeat, prDoc, prTypo, issueFeat, issueDoc, score]) => {
-            csvContent += `${name},${prFeat},${prDoc},${prTypo},${issueFeat},${issueDoc},${score}\n`;
-            totalScore += score;
+        sortedScores.forEach(([name, prFeat, prDoc, prTypo, issueFeat, issueDoc, score]) => {
+            const rank = ranks[repoScores.findIndex(s => 
+                s[0] === name && s[6] === score
+            )];
+            csvContent += `${rank},${name},${prFeat},${prDoc},${prTypo},${issueFeat},${issueDoc},${score}\n`;
         });
 
         const filePath = path.join(outputDir, `${repoName}_score.csv`);

--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -199,70 +199,121 @@ class RepoAnalyzer {
         });
     }
 
+    /**
+     * PR과 이슈의 조정된 개수를 계산
+     * @param {number} p_fb - 기능/버그 PR 개수
+     * @param {number} p_d - 문서 PR 개수
+     * @param {number} p_t - 오타 수정 PR 개수
+     * @param {number} i_fb - 기능/버그 이슈 개수
+     * @param {number} i_d - 문서 이슈 개수
+     * @returns {Object} 조정된 PR과 이슈 개수
+     */
+    _calculateAdjustedCounts(p_fb, p_d, p_t, i_fb, i_d) {
+        const total_pr = p_fb + p_d + p_t;
+        const total_issue = i_fb + i_d;
+
+        // 활동이 전혀 없는 경우
+        if (total_pr === 0 && total_issue === 0) {
+            return {
+                pr: { fb: 0, doc: 0, typo: 0 },
+                issue: { fb: 0, doc: 0 }
+            };
+        }
+
+        // 복수의 활동이 있는 경우 (PR이나 이슈가 2개 이상)
+        if ((p_fb > 0 || p_d > 0 || p_t > 0) && (total_pr > 1 || total_issue > 1)) {
+            const temp_p_fb = (p_fb === 0 && p_d > 0) ? 1 : p_fb;
+            const p_valid = temp_p_fb + Math.min(p_d, 3 * temp_p_fb) + Math.min(p_t, 3 * temp_p_fb);
+            const i_valid = Math.min(i_fb + i_d, 4 * p_valid);
+
+            return {
+                pr: {
+                    fb: p_fb,
+                    doc: Math.min(p_d, 3 * temp_p_fb),
+                    typo: Math.min(p_t, 3 * temp_p_fb)
+                },
+                issue: {
+                    fb: Math.min(i_fb, i_valid),
+                    doc: i_valid - Math.min(i_fb, i_valid)
+                }
+            };
+        }
+
+        // 단일 활동만 있는 경우
+        return {
+            pr: { fb: p_fb, doc: p_d, typo: p_t },
+            issue: { fb: i_fb, doc: i_d }
+        };
+    }
+
+    /**
+     * 조정된 개수를 바탕으로 점수 계산
+     * @param {Object} counts - 조정된 PR과 이슈 개수
+     * @returns {Object} 계산된 점수
+     */
+    _calculateScoresFromCounts(counts) {
+        return {
+            pr: {
+                fb: counts.pr.fb * SCORE.prFeature,
+                doc: counts.pr.doc * SCORE.prDoc,
+                typo: counts.pr.typo * SCORE.prTypo
+            },
+            issue: {
+                fb: counts.issue.fb * SCORE.issueFeature,
+                doc: counts.issue.doc * SCORE.issueDoc
+            }
+        };
+    }
+
+    /**
+     * 개별 참여자의 점수를 계산
+     * @param {string} participant - 참여자 ID
+     * @param {Object} activities - 참여자의 활동 정보
+     * @returns {Array} 계산된 점수 배열
+     */
+    _calculateParticipantScore(participant, activities) {
+        // 1. 기본 활동 수치 추출
+        const p_fb = activities.pullRequests.bugAndFeat || 0;
+        const p_d = activities.pullRequests.doc || 0;
+        const p_t = activities.pullRequests.typo || 0;
+        const i_fb = activities.issues.bugAndFeat || 0;
+        const i_d = activities.issues.doc || 0;
+
+        // 2. 조정된 개수 계산
+        const adjustedCounts = this._calculateAdjustedCounts(p_fb, p_d, p_t, i_fb, i_d);
+        
+        // 3. 점수 계산
+        const scores = this._calculateScoresFromCounts(adjustedCounts);
+        
+        // 4. 총점 계산
+        const totalScore = Object.values(scores.pr).reduce((sum, score) => sum + score, 0) +
+                         Object.values(scores.issue).reduce((sum, score) => sum + score, 0);
+
+        return [
+            participant,
+            scores.pr.fb,
+            scores.pr.doc,
+            scores.pr.typo,
+            scores.issue.fb,
+            scores.issue.doc,
+            totalScore
+        ];
+    }
+
+    /**
+     * 전체 저장소의 점수를 계산하는 메인 함수
+     * @returns {Map} - 저장소별 참여자 점수 정보
+     */
     calculateScores() {
         const allRepoScores = new Map();
 
         this.participants.forEach((repoActivities, repoName) => {
-            const repoScores = [];
+            const repoScores = Array.from(repoActivities.entries())
+                .map(([participant, activities]) => 
+                    this._calculateParticipantScore(participant, activities)
+                )
+                .sort((a, b) => b[6] - a[6]); // 총점 기준 내림차순 정렬
 
-            for (const [participant, activities] of repoActivities.entries()) {
-                const p_fb = activities.pullRequests.bugAndFeat || 0;
-                const p_d = activities.pullRequests.doc || 0;
-                const p_t = activities.pullRequests.typo || 0; // 추가: typo PR
-                const i_fb = activities.issues.bugAndFeat || 0;
-                const i_d = activities.issues.doc || 0;
-
-                let p_fb_at, p_d_at, p_t_at, i_fb_at, i_d_at; // 변경: p_t_at 추가
-
-                const total_pr = p_fb + p_d + p_t; // 변경: typo PR 포함
-                const total_issue = i_fb + i_d;
-
-                if (total_pr === 0 && total_issue === 0) {
-                    p_fb_at = 0;
-                    p_d_at = 0;
-                    p_t_at = 0; // 추가
-                    i_fb_at = 0;
-                    i_d_at = 0;
-                } else if ((p_fb > 0 || p_d > 0 || p_t > 0) && (total_pr > 1 || total_issue > 1)) { // 변경: typo PR 조건 추가
-                    const temp_p_fb = (p_fb === 0 && p_d > 0) ? 1 : p_fb;
-                    const p_valid = temp_p_fb + Math.min(p_d, 3 * temp_p_fb) + Math.min(p_t, 3 * temp_p_fb); // 변경: typo PR 포함
-                    const i_valid = Math.min(i_fb + i_d, 4 * p_valid);
-
-                    p_fb_at = p_fb;
-                    p_d_at = Math.min(p_d, 3 * temp_p_fb);
-                    p_t_at = Math.min(p_t, 3 * temp_p_fb); // 추가: typo PR 제한
-                    i_fb_at = Math.min(i_fb, i_valid);
-                    i_d_at = i_valid - i_fb_at;
-                } else {
-                    p_fb_at = p_fb;
-                    p_d_at = p_d;
-                    p_t_at = p_t; // 추가
-                    i_fb_at = i_fb;
-                    i_d_at = i_d;
-                }
-
-                const p_fb_score = p_fb_at * SCORE.prFeature;
-                const p_d_score = p_d_at * SCORE.prDoc;
-                const p_t_score = p_t_at * SCORE.prTypo; // 추가: typo PR 점수 계산
-                const i_fb_score = i_fb_at * SCORE.issueFeature;
-                const i_d_score = i_d_at * SCORE.issueDoc;
-
-                const totalScore = p_fb_score + p_d_score + p_t_score + i_fb_score + i_d_score; // 변경: p_t_score 포함
-
-                repoScores.push([
-                    participant,
-                    p_fb_score,
-                    p_d_score,
-                    p_t_score, // 추가
-                    i_fb_score,
-                    i_d_score,
-                    totalScore
-                ]);
-
-            }
-
-            // 정렬 후 저장
-            repoScores.sort((a, b) => b[6] - a[6]); // 변경: totalScore 인덱스 6으로 조정
             allRepoScores.set(repoName, repoScores);
         });
 


### PR DESCRIPTION
#295 

점수 계산 로직이 더 명확하고 관리하기 쉬운 구조로 변경되었습니다. 각 함수는 다음과 같은 역할을 수행합니다:

_calculateAdjustedCounts: PR과 이슈의 조정된 개수를 계산
_calculateScoresFromCounts: 조정된 개수를 바탕으로 점수 계산
_calculateParticipantScore: 개별 참여자의 점수를 계산
calculateScores: 전체 저장소의 점수를 계산하는 메인 함수
