### PR TITLE
[FEAT] 동점자에 대한 동일 순위 처리 기능 추가에 대한 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -422,10 +422,28 @@ class RepoAnalyzer {
 
             // 점수에 따라 정렬하고 순위를 추가
             const sortedScores = [...repoScores].sort((a, b) => b[6] - a[6]);
-            const labels = sortedScores.map(([name], index) => {
-                const rank = index + 1;
-                const suffix = rank === 1 ? 'st' : rank === 2 ? 'nd' : rank === 3 ? 'rd' : 'th';
-                return `${rank}${suffix} ${name}`;
+
+            // 동점자 처리를 위한 순위 계산
+            let currentRank = 1;
+            let currentScore = sortedScores[0][6];  // 첫 번째 점수
+            let skipCount = 0;
+
+            const labels = sortedScores.map((score, index) => {
+                const [name, , , , , , totalScore] = score;
+                
+                // 점수가 변경되면 순위 업데이트
+                if (totalScore < currentScore) {
+                    currentRank += skipCount + 1;
+                    currentScore = totalScore;
+                    skipCount = 0;
+                } else if (totalScore === currentScore) {
+                    skipCount++;
+                }
+
+                const suffix = currentRank === 1 ? 'st' : 
+                              currentRank === 2 ? 'nd' : 
+                              currentRank === 3 ? 'rd' : 'th';
+                return `${currentRank}${suffix} ${name}`;
             });
 
             const data = sortedScores.map(array => array[6]); // totalScore 값들의 배열


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/310

## Specific Version
https://github.com/oss2025hnu/reposcore-js/commit/1829ccda3f6292e6f50fd52d00f9f01b33c4cf93

## 변경 내용
참가자의 점수가 동점일 시, 공동 순위로 처리하게 하였습니다.

![image](https://github.com/user-attachments/assets/4bfea0e6-f54a-4c20-ab9e-bbd9d44bfe5c)
