### PR TITLE
[feat] --format all 옵션 시 통합 HTML 리포트 생성 기능 추가 #322

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ import {jsonToMap, mapToJson, log, loadCache, saveCache, updateEnvToken, setText
 import getRateLimit from './lib/checkLimit.js';
 import ThemeManager from './lib/ThemeManager.js';
 
+import { generateReportHtml } from './lib/htmlGenerator.js';
+
 dotenv.config();
 
 program
@@ -65,6 +67,7 @@ if (!validFormats.includes(options.format)) {
     console.error(`에러: 유효하지 않은 형식입니다: "${options.format}"\n사용 가능한 형식: ${validFormats.join(', ')}`);
     process.exit(1);
 }
+
 
 // 기존 실행 로직을 함수로 분리
 async function main() {
@@ -161,6 +164,14 @@ async function main() {
             }
             await analyzer.updateUserInfo(scores);
             realNameScore = await analyzer.transformUserIdToName(scores);
+        }
+
+        //csv, png, txt를 포함하여 html 생성
+        if (options.format === 'all') {
+            await analyzer.generateTable(realNameScore || scores || [], options.output);
+            await analyzer.generateCsv(realNameScore || scores || [], options.output);
+            await analyzer.generateChart(realNameScore || scores || [], options.output);
+            await generateReportHtml(program.args[0].split('/')[1], options.output); // repo 이름만 추출
         }
 
         // Calculate AverageScore

--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -1,0 +1,76 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+// 특수문자 라인 거르기 + 컬럼 정리
+function parseTableText(rawText) {
+    const rows = rawText
+        .split('\n')
+        .filter(line => !/^[\s│├┤┬┴┼┌┐└┘─]+$/.test(line)) // 선긋기 문자는 제거
+        .map(line => {
+            // 양옆 공백 제거하고, '│' 기준으로 분리
+            const cols = line.trim().split('│')
+                .map(col => col.trim())
+                .filter(col => col.length > 0); // 빈 컬럼 제거
+
+            return `<tr>${cols.map(col => `<td>${col}</td>`).join('')}</tr>`;
+        });
+
+    return `<table border="1">${rows.join('\n')}</table>`;
+}
+
+export async function generateReportHtml(repoName, outputDir = '.') {
+    const tablePath = path.join(outputDir, `${repoName}.txt`);
+    const chartPath = `${repoName}_chart.png`;
+    const csvPath = `${repoName}_score.csv`;
+    const reportPath = path.join(outputDir, 'report.html');
+
+    let tableHtml;
+    try {
+        const tableText = await fs.readFile(tablePath, 'utf-8');
+        tableHtml = parseTableText(tableText);
+    } catch {
+        tableHtml = '<p><i>표 파일이 없습니다.</i></p>';
+    }
+
+    const chartHtml = `<img src="${chartPath}" alt="Chart" style="max-width:100%; border:1px solid #ccc;">`;
+    const csvHtml = `<a href="${csvPath}" download>CSV 파일 다운로드</a>`;
+
+    const finalHtml = `
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>${repoName} 기여도 보고서</title>
+    <style>
+        body { font-family: sans-serif; padding: 2rem; line-height: 1.6; }
+        h1 { font-size: 2rem; }
+        h2 { margin-top: 2rem; }
+        table { border-collapse: collapse; width: 100%; margin-top: 1rem; }
+        td, th { border: 1px solid #aaa; padding: 8px; text-align: center; }
+        tr:nth-child(even) { background-color: #f9f9f9; }
+    </style>
+</head>
+<body>
+    <h1>${repoName} 기여도 분석 보고서</h1>
+
+    <section>
+        <h2>1. 차트</h2>
+        ${chartHtml}
+    </section>
+
+    <section>
+        <h2>2. 점수 테이블</h2>
+        ${tableHtml}
+    </section>
+
+    <section>
+        <h2>3. CSV 다운로드</h2>
+        ${csvHtml}
+    </section>
+</body>
+</html>
+`;
+
+    await fs.writeFile(reportPath, finalHtml, 'utf-8');
+    console.log(`✅ 통합 HTML 보고서가 생성되었습니다: ${reportPath}`);
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "clean": "rm -rf results **/*.png *-lock.json",
         "test": "jest",
         "lint": "eslint .",
-        "readme": "make readme"
+        "readme": "make readme",
+        "report": "http-server results -p 3000 -o report.html"
     },
     "devDependencies": {
         "dotenv": "^16.5.0",


### PR DESCRIPTION
## Issue ID 
--format all 옵션 시 통합 HTML 리포트 생성 기능 추가 #322

## Specific Version
f51037b
3832ac0

## 변경 내용
lib/htmlGenerator.js 파일 생성됨
report.html 자동 생성 기능 추가 (차트 + 테이블 + CSV 링크 포함)
--format all 옵션에서만 생성되도록 조건 설정 (그러나 default가 all로 되어있음)
npm run report 명령어로 브라우저에서 열람가능 ( http-server 실행 되고 report.html 링크를 타고 통합 파일 열람 )

