### PR TITLE
[FEAT] 차트에서 "순위 이름" 대신 "이름 순위"로 나타나도록 변경에 대한 PR

### DIFF
--- a/lib/ChartGenerator.js
+++ b/lib/ChartGenerator.js
@@ -53,7 +53,7 @@ export class ChartGenerator {
             const suffix = currentRank === 1 ? 'st' : 
                           currentRank === 2 ? 'nd' : 
                           currentRank === 3 ? 'rd' : 'th';
-            return `${currentRank}${suffix} ${name}`;
+            return `${name} (${currentRank}${suffix}) `;
         });
     }
 


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/342

## Specific Version
https://github.com/oss2025hnu/reposcore-js/commit/5e42950e751f19c9ce0158c7340a4ef1ea2431cc

## 변경 내용
차트 Y축의 순위, ID 표시의 순서를 ID, 순서로 변경하여 가독성을 향상시켰습니다.
![image](https://github.com/user-attachments/assets/c10fb669-4504-4114-b1d1-720d4c553172)
