### PR TITLE
[FEAT] 그래프에 DOC/FEAT/BUG 점수 비율 텍스트 추가

### DIFF
--- a/lib/ChartGenerator.js
+++ b/lib/ChartGenerator.js
@@ -4,6 +4,8 @@ import { ChartJSNodeCanvas } from 'chartjs-node-canvas';
 import { CHART_CONFIG } from './chartConfig.js';
 import { log } from './Util.js';
 
+const stripAnsi = (str) => str.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
+
 export class ChartGenerator {
     /**
      * @param {Object} config - 차트 설정
@@ -53,7 +55,9 @@ export class ChartGenerator {
             const suffix = currentRank === 1 ? 'st' : 
                           currentRank === 2 ? 'nd' : 
                           currentRank === 3 ? 'rd' : 'th';
-            return `${name} (${currentRank}${suffix}) `;
+            const label = `${name} (${currentRank}${suffix})`;
+
+            return stripAnsi(label); 
         });
     }
 
@@ -136,7 +140,23 @@ export class ChartGenerator {
                         font: this.config.fonts.dataLabels,
                         anchor: 'end',
                         align: 'end',
-                        offset: 4
+                        offset: 4,
+                        formatter: (value, context) => {
+                            const index = context.dataIndex;
+                            const original = processedData.originalScores[index];
+                            if (!original) return value;
+                        
+                            const totalScore = parseInt(stripAnsi(original[6].toString()), 10);
+                            const prFeat = parseInt(stripAnsi(original[1].toString()), 10);
+                            const prDoc = parseInt(stripAnsi(original[2].toString()), 10);
+                            const prTypo = parseInt(stripAnsi(original[3].toString()), 10);
+                        
+                            const featRatio = totalScore > 0 ? ((prFeat / totalScore) * 100).toFixed(0) : 0;
+                            const docRatio = totalScore > 0 ? ((prDoc / totalScore) * 100).toFixed(0) : 0;
+                            const typoRatio = totalScore > 0 ? ((prTypo / totalScore) * 100).toFixed(0) : 0;
+                        
+                            return `${totalScore}점 | F ${featRatio}% / D ${docRatio}% / T ${typoRatio}%`;
+                        }                                                                      
                     }
                 },
                 scales: {
@@ -177,10 +197,16 @@ export class ChartGenerator {
             const height = participantCount * this.config.dimensions.barHeight;
             const canvas = this._initializeCanvas(height);
 
+            const cleanedScores = sortedScores.map(score => {
+                const cleanedName = stripAnsi(score[0]);
+                return [cleanedName, ...score.slice(1)];
+            }); 
+
             const processedData = {
-                labels: this._generateLabels(sortedScores),
-                data: this._extractScores(sortedScores),
-                colors: this._generateColors(this._extractScores(sortedScores))
+                labels: this._generateLabels(cleanedScores),
+                data: this._extractScores(cleanedScores),
+                colors: this._generateColors(this._extractScores(cleanedScores)),
+                originalScores: cleanedScores
             };
 
             const configuration = this._createConfiguration(processedData, participantCount);


### PR DESCRIPTION
## Issue ID 
[FEAT] 그래프에 DOC/FEAT/BUG 점수 비율 텍스트 추가 #303

## Specific Version
6d23bd4

## 변경 내용
- 점수 옆에 총점 + FEAT/DOC/TYPO 비율을 표시하도록 ChartGenerator.js 수정
- 이름과 점수에 숨겨진 ANSI 색상코드 제거(깨짐 방지) 처리 추가
- 총점이 0일 때 비율 계산 에러를 막는 예외처리 추가