### PR TITLE
[REFACT] 참여횟수 count 관련 csv 테이블와 점수 관련 csv 테이블을 통합합니다 에 대한 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -22,7 +22,7 @@ const SCORE = {
 
 const EXCLUDE_USERS = ['kyagrd', 'kyahnu'];
 
-const CSV_HEADER = 'name,feat/bug PR,doc PR,typo PR,feat/bug issue,doc issue,total\n';
+const CSV_HEADER = 'name,feat/bug PR count,feat/bug PR score,doc PR count,doc PR score,typo PR count,typo PR score,feat/bug issue count,feat/bug issue score,doc issue count,doc issue score,total\n';
 
 // 사용자 초기화 함수
 function initParticipant(map, login) {
@@ -454,50 +454,37 @@ class RepoAnalyzer {
         }
     }
 
-    async generateScoreCsv(repoName, repoScores, outputDir) {
+    async generateCombinedCsv(repoName, repoScores, repoActivities, outputDir) {
         let csvContent = CSV_HEADER;
         let totalScore = 0;
 
-        repoScores.forEach(([name, prFeat, prDoc, prTypo, issueFeat, issueDoc, score]) => {
-            csvContent += `${name},${prFeat},${prDoc},${prTypo},${issueFeat},${issueDoc},${score}\n`;
-            totalScore += score;
-        });
-
-        const filePath = path.join(outputDir, `${repoName}_score.csv`);
-        await fs.writeFile(filePath, csvContent);
-        log(`점수 집계 CSV 파일이 생성되었습니다: ${filePath}`, '생성');
-    }
-
-    async generateCountCsv(repoName, repoActivities, outputDir) {
-        let csvContent = CSV_HEADER;
-        let totalCount = 0;
-
+        // 참여자별로 점수와 횟수를 결합
         for (const [participant, activities] of repoActivities.entries()) {
-            const p_fb = activities.pullRequests.bugAndFeat || 0;
-            const p_d = activities.pullRequests.doc || 0;
-            const p_t = activities.pullRequests.typo || 0;
-            const i_fb = activities.issues.bugAndFeat || 0;
-            const i_d = activities.issues.doc || 0;
-            const count = p_fb + p_d + p_t + i_fb + i_d;
+            const p_fb_count = activities.pullRequests.bugAndFeat || 0;
+            const p_d_count = activities.pullRequests.doc || 0;
+            const p_t_count = activities.pullRequests.typo || 0;
+            const i_fb_count = activities.issues.bugAndFeat || 0;
+            const i_d_count = activities.issues.doc || 0;
 
-            csvContent += `${participant},${p_fb},${p_d},${p_t},${i_fb},${i_d},${count}\n`;
-            totalCount += count;
+            // 해당 참여자의 점수 찾기
+            const scoreData = repoScores.find(([name]) => name === participant) || [participant, 0, 0, 0, 0, 0, 0];
+            const [, p_fb_score, p_d_score, p_t_score, i_fb_score, i_d_score, total] = scoreData;
+
+            csvContent += `${participant},${p_fb_count},${p_fb_score},${p_d_count},${p_d_score},${p_t_count},${p_t_score},${i_fb_count},${i_fb_score},${i_d_count},${i_d_score},${total}\n`;
+            totalScore += total;
         }
 
-        const filePath = path.join(outputDir, `${repoName}_count.csv`);
+        const filePath = path.join(outputDir, `${repoName}_combined.csv`);
         await fs.writeFile(filePath, csvContent);
-        log(`활동 개수 CSV 파일이 생성되었습니다: ${filePath}`, 'INFO');
+        log(`통합 CSV 파일이 생성되었습니다: ${filePath}`, 'INFO');
     }
 
     async generateCsv(allRepoScores, outputDir = '.') {
         const promises = Array.from(allRepoScores).map(async ([repoName, repoScores]) => {
-            // 점수 CSV 생성
-            await this.generateScoreCsv(repoName, repoScores, outputDir);
-
-            // 활동 개수 CSV 생성
+            // 통합 CSV 생성
             const repoActivities = this.participants.get(repoName);
             if (repoActivities) {
-                await this.generateCountCsv(repoName, repoActivities, outputDir);
+                await this.generateCombinedCsv(repoName, repoScores, repoActivities, outputDir);
             }
         });
 


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/341

## Specific Version
7aa2373daf3d6dd38d220afce9efbbd4d9344862

## 변경 내용
참여횟수 count 관련 csv 테이블와 점수 관련 csv 테이블이 두가지 파일로 각각 따로 생성되고있는 것을 하나로 합쳤습니다.