### PR TITLE
[DOC] README.md 내 중복 CLI 옵션 표기 수정

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,9 +42,8 @@ program
         new Option('--check-limit', 'Check GitHub API rate limit')
     )
     .option('-t, --theme <theme>', 'Set theme for analysis (default/dark)')
-    .option('--create-theme <theme>', '새 테마 생성 (JSON 형식)')
-    .option('--change-theme <theme>', '사용할 테마 선택 (default, dark, 또는 커스텀 테마)')
-    .option('--create-theme <json>', 'Create custom theme')
+    .option('--create-theme <json>', '새 테마 생성 (JSON 형식)')
+    .option('--change-theme <name>', '사용할 테마 선택 (default, dark, 또는 커스텀 테마)')
     .arguments('<path..>','Repository path (e.g., user/repo)');
 
 program.parse(process.argv);


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/355

## Specific Version
ad3262ea079245acfac79e57e3a9c44ad7fae6cd

## 변경 내용
--create-theme 옵션이 두 번 등장하고 있으며, <theme>와 <json>으로 표기된 인자도 모호하게 겹치고 있는 부분 수정