### PR TITLE
저장소 분석 결과물 중 그래프 이미지의 오른쪽이 잘려 보이는 현상 수정

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "mechatroner.rainbow-csv"
+      ]
+    }
+  }
+}

--- a/lib/ChartGenerator.js
+++ b/lib/ChartGenerator.js
@@ -20,8 +20,7 @@ export class ChartGenerator {
      * 차트 캔버스 초기화
      * @returns {ChartJSNodeCanvas}
      */
-    _initializeCanvas(height) {
-        const { width } = this.config.dimensions;
+    _initializeCanvas(width, height) {
         return new ChartJSNodeCanvas({
             width,
             height,
@@ -120,6 +119,11 @@ export class ChartGenerator {
             options: {
                 responsive: false,
                 indexAxis: 'y',
+                layout: {
+                    padding: {
+                        right: Math.ceil(maxScore * 0.1)
+                    }
+                },
                 plugins: {
                     title: {
                         display: true,
@@ -168,7 +172,7 @@ export class ChartGenerator {
                             autoSkip: false,
                             color: this.theme.chart.textColor
                         },
-                        max: maxScore + 20
+                        max: Math.ceil(maxScore * 1.4)
                     },
                     y: {
                         grid: {
@@ -194,8 +198,11 @@ export class ChartGenerator {
         try {
             const sortedScores = [...repoScores].sort((a, b) => b[6] - a[6]);
             const participantCount = sortedScores.length;
+
+            const maxScore = Math.max(...this._extractScores(sortedScores));
+            const width = this.config.dimensions.width + Math.ceil(maxScore / 100) * 100;
             const height = participantCount * this.config.dimensions.barHeight;
-            const canvas = this._initializeCanvas(height);
+            const canvas = this._initializeCanvas(width, height);
 
             const cleanedScores = sortedScores.map(score => {
                 const cleanedName = stripAnsi(score[0]);


### PR DESCRIPTION
## Issue ID 
[BUG] 막대 차트에서 텍스트가 잘려 보이는 현상 https://github.com/oss2025hnu/reposcore-js/issues/356 에 대한 PR입니다.

## Specific Version
1e1054c796f345834992512f65e99fc6e91283bf

## 변경 내용
- canvas width를 사용자의 점수에 따라 동적으로 증가하도록 수정
- x축의 max값을 기존에 +20으로 고정값으로 늘리는 방식에서 * 1.4와 같이 값에 비례하게 늘어나도록 수정
- 출력값 오른쪽에 padding을 넣어 여유 공간을 확보하도록 수정

## 추가 내용
해당 이슈는 bug로 올라왔으나, 버그를 해결하며 정적이던 width값을 동적으로 수정하여 코드의 유지보수 측면에서 크게 향상을 이뤄냈기에 FEAT라벨 건의드립니다.