### PR TITLE
[FEAT] .txt출력에 기여자 등수 추가

### DIFF
--- a/lib/tableGenerator.js
+++ b/lib/tableGenerator.js
@@ -47,6 +47,7 @@ export default class TableGenerator {
             // 참가자의 최대 너비 계산
             let maxNameWidth = 20; // 최소 너비
             repoScores.forEach(([name, , , , , , total]) => {
+                // 뱃지
                 const badge = getBadge(total);
                 // 뱃지에서 이모지만 추출
                 const badgeEmoji = badge.split(' ')[0];
@@ -55,6 +56,14 @@ export default class TableGenerator {
                 maxNameWidth = Math.max(maxNameWidth, displayWidth + 2); // 여유 공간 추가
             });
 
+            // 순위 계산 함수
+            function calculateRank(currentIndex, currentTotal, prevTotal, prevRank) {
+                return currentTotal === prevTotal ? prevRank : currentIndex + 1;
+            }
+            // 참여율 계산 함수
+            function calculateRate(score, totalScore) {
+                return totalScore > 0 ? ((score / totalScore) * 100).toFixed(2) : '0.00';
+            }
             // 동적 colWidths 설정
             const colWidths = [
                 6,            //순위
@@ -85,21 +94,23 @@ export default class TableGenerator {
             let prevTotal = null;
             let rank = 0;
             repoScores.forEach(([name, p_fb_score, p_d_score, p_t_score, i_fb_score, i_d_score, total], index) => { // 변경: p_t_score 추가
-                //순위 (동점자 순위 처리)
-                const isSameAsPrevious = total === prevTotal;
-                const currentRank = isSameAsPrevious ? rank : index + 1;
+                // 순위 계산
+                rank = calculateRank(index, total, prevTotal, rank);
                 prevTotal = total;
-                rank = currentRank;
-                //참여율
-                const rate = totalScore > 0 ? ((total / totalScore) * 100).toFixed(2) : '0.00';
+
+                // 참여율 계산
+                const rate = calculateRate(total, totalScore);
+
                 //뱃지
                 const badge = getBadge(total);
+                
                 // 뱃지에서 이모지만 추출
                 const badgeEmoji = badge.split(' ')[0];
                 const nameWithBadge = `${badgeEmoji} ${name}`;
+
                 // CLI에 표시될 테이블 행
                 table.push([
-                    currentRank,
+                    rank,
                     nameWithBadge,
                     p_fb_score,
                     p_d_score,


### PR DESCRIPTION
## Issue ID 
#383 [FEAT] .txt출력에도 등수 정보 추가 요청

## Specific Version
(https://github.com/oss2025hnu/reposcore-js/commit/5638694bbdfbd3086b02d07d3532a5aef0909f08)

## 변경 내용
- .txt 형식으로 출력되는 기여자 목록에 등수(rank) 정보가 포함되도록 로직 수정
- 동점자 처리 시 같은 등수를 부여하는 calculateRank() 함수 추가
- 총점 대비 개인 점수의 백분율을 계산하는 calculateRate() 함수 추가