### PR TITLE
[FEAT] 결과 확인하는 result 디렉토리 내 레포지토리 별 디렉토리 분리

### DIFF
--- a/lib/ChartGenerator.js
+++ b/lib/ChartGenerator.js
@@ -217,7 +217,9 @@ export class ChartGenerator {
             const configuration = this._createConfiguration(processedData, participantCount);
             const buffer = await canvas.renderToBuffer(configuration);
             
-            const filePath = path.join(outputDir, `${repoName}_chart.png`);
+            const repoSpecificDir = path.join(outputDir, repoName);
+            await fs.mkdir(repoSpecificDir, { recursive: true });
+            const filePath = path.join(repoSpecificDir, `${repoName}_chart.png`);
             await fs.writeFile(filePath, buffer);
             log(`차트 이미지가 저장되었습니다: ${filePath}`);
         } catch (error) {

--- a/lib/csvGenerator.js
+++ b/lib/csvGenerator.js
@@ -28,7 +28,9 @@ class CsvGenerator {
             totalScore += total;
         }
 
-        const filePath = path.join(outputDir, `${repoName}_combined.csv`);
+        const repoSpecificDir = path.join(outputDir, repoName);
+        await fs.mkdir(repoSpecificDir, { recursive: true });
+        const filePath = path.join(repoSpecificDir, `${repoName}_combined.csv`);
         await fs.writeFile(filePath, csvContent);
         log(`통합 CSV 파일이 생성되었습니다: ${filePath}`, 'INFO');
     }

--- a/lib/tableGenerator.js
+++ b/lib/tableGenerator.js
@@ -111,8 +111,9 @@ export default class TableGenerator {
                 ]);
             });
 
-            const filePath = path.join(output, `${repoName}.txt`);
-            await fs.mkdir(output, { recursive: true });
+            const repoSpecificDir = path.join(output, repoName);
+            await fs.mkdir(repoSpecificDir, { recursive: true });
+            const filePath = path.join(repoSpecificDir, `${repoName}.txt`);
 
             const now = new Date();
             const dateStr = now.toLocaleString('en-US', { timeZone: 'Asia/Seoul' });


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/376

## Specific Version
https://github.com/oss2025hnu/reposcore-js/commit/5638694bbdfbd3086b02d07d3532a5aef0909f08

## 변경 내용
result 폴더에 레포지토리별 분류 및 교수님의 의견인 `_combined.csv`를 `_data.csv`로 나오도록 반영
기존 PR 머지 충돌로 인해 다시 수정 후 PR 작성