### PR TITLE
[FEAT] -f 옵션에 html 단독 출력 형식 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ npm install
 ## Usage
 아래는 `node index.js -h` 또는 `node index.js --help` 실행 결과를 붙여넣은 것이므로
 명령줄 관련 코드가 변경되면 아래 내용도 그에 맞게 수정해야 함.
-
-만약 명령줄 코드가 변경될 경우, node lib/GenerateReadme.js를 통해 Readme.md파일을 최신화 할 것.
+만약 명령줄 코드가 변경될 경우, node lib/GenerateReadme.js를 통헤 Readme.md파일을 최신화 할 것.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Usage: node index.js [옵션] <저장소 경로..>
 Options:
   -a, --api-key <token>  GitHub 액세스 토큰 (선택)
   -o, --output <dir>     결과 저장 폴더 (default: "results")
-  -f, --format <type>    출력 형식 (choices: "text", "table", "chart", "all",
-                         default: "all")
+  -f, --format <type>    출력 형식 (choices: "text", "table", "chart", "html",
+                         "all", default: "all")
   -c, --use-cache        저장된 GitHub 데이터 사용
   -u, --user-name        사용자 실명 표시
   --check-limit          GitHub API 사용량 확인

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ program
             .default('results')
     )
     .addOption(new Option('-f, --format <type>', '출력 형식')
-        .choices(['text', 'table', 'chart', 'all'])
+        .choices(['text', 'table', 'chart', 'html','all'])
         .default('all')
     )
     .addOption(
@@ -62,7 +62,7 @@ if (options.checkLimit) {
 }
 
 
-const validFormats = ['text', 'table', 'chart', 'all']; // 수정: both -> all, text 추가
+const validFormats = ['text', 'table', 'chart', 'html', 'all']; // 수정: both -> all, text 추가
 if (!validFormats.includes(options.format)) {
     console.error(`에러: 유효하지 않은 형식입니다: "${options.format}"\n사용 가능한 형식: ${validFormats.join(', ')}`);
     process.exit(1);
@@ -191,7 +191,18 @@ async function main() {
 
         // 디렉토리 생성
         await fs.mkdir(options.output, {recursive: true});
-
+        
+        // format이 html인 경우: 오직 HTML만 생성하고 종료
+        if (options.format === 'html') {
+        const repositories = program.args;
+        const resultsDir = options.output;
+        const htmlContent = await generateHTML(repositories, resultsDir);
+        const htmlFilePath = path.join(resultsDir, 'index.html');
+        await fs.writeFile(htmlFilePath, htmlContent);
+        console.log(`HTML 보고서가 ${htmlFilePath}에 생성되었습니다.`);
+        return;
+        }
+        
         // Generate outputs based on format
         if (['all', 'text'].includes(options.format)) {
             await analyzer.generateTable(realNameScore || scores || [], options.output);


### PR DESCRIPTION
## Issue ID 
[FEAT] -f 옵션에 html 추가 요청 #441

## Specific Version
d915bef

## 변경 내용
- `--format html` 옵션 추가
- `--format html` 사용 시 `.txt`, `.csv`, `.png`는 생성되지 않고 `index.html`만 생성됨
- 잘못된 옵션 입력 시 에러 출력 (`html` 포함된 choices, 검증 처리 포함)