### PR TITLE
index.js 위치 lib 폴더 내로 이동

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,13 +7,13 @@ import {fileURLToPath} from 'url';
 import dotenv from 'dotenv';
 import {program, Option} from 'commander';
 
-import RepoAnalyzer from './lib/analyzer.js';
-import {jsonToMap, mapToJson, log, loadCache, saveCache, updateEnvToken, setTextColor} from './lib/Util.js';
+import RepoAnalyzer from './analyzer.js';
+import {jsonToMap, mapToJson, log, loadCache, saveCache, updateEnvToken, setTextColor} from './Util.js';
 
-import getRateLimit from './lib/checkLimit.js';
-import ThemeManager from './lib/ThemeManager.js';
+import getRateLimit from './checkLimit.js';
+import ThemeManager from './ThemeManager.js';
 
-import { generateHTML } from './lib/htmlGenerator.js';
+import { generateHTML } from './htmlGenerator.js';
 
 dotenv.config();
 


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/450

## Specific Version
1c16f586d37c2701dcd1b368f9fe6e608b73a2d6

## 변경 내용
index.js 위치 lib 폴더로 이동
이슈에 eslint.config.js 도 lib 폴더 내로 이동하자고 했지만 eslint.config.js 는  
프로젝트 전체에 대해 ESLint 설정을 적용하는 역할을 하므로 프로젝트의 루트 디렉토리에 넣는 게 일반적임. 따라서 eslint.config.js는 이동하지 않음