### PR TITLE
[BUG] 인코딩 언어 지정

### DIFF
--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -92,7 +92,7 @@ export async function generateHTML(repositories, resultsDir) {
 
     let html = `
 <!DOCTYPE html>
-<html>
+<html lang=ko>
 <head>
   <meta charset="UTF-8">
   <title>RepoScore Results</title>

--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -94,6 +94,7 @@ export async function generateHTML(repositories, resultsDir) {
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="UTF-8">
   <title>RepoScore Results</title>
   <style>
     body { font-family: sans-serif; }

--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -92,7 +92,7 @@ export async function generateHTML(repositories, resultsDir) {
 
     let html = `
 <!DOCTYPE html>
-<html lang=ko>
+<html lang="ko">
 <head>
   <meta charset="UTF-8">
   <title>RepoScore Results</title>


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/420

## Specific Version
e1f61abfc82b3ac5e1b7641de08098921dde265c

## 변경 내용
`htmlGenrator.js`에서 생성되는 HTML 파일에 문자 인코딩이 지정되지 않던 문제를 해결하였습니다.
HTML <head> 태그 내에 <meta charset="UTF-8">을 추가하여 한글과 같은 문자가 올바르게 표시되도록 수정하였습니다.

