### PR TITLE
[FEAT] calculateAverageScore 빈 배열 예외 처리 PR

### DIFF
--- a/lib/analyzer.js
+++ b/lib/analyzer.js
@@ -187,18 +187,25 @@ class RepoAnalyzer {
     }
 
     calculateAverageScore(allRepoScores) {
+        const averages = new Map();
+        
         allRepoScores.forEach((repoScores, repoName) => {
             const values = repoScores.map(item => item[1]);
+            
             if (values.length === 0) {
-                log('참가자가 없어 평균을 계산할 수 없습니다.\n', 'INFO');
+                log(`${repoName}: 참가자가 없어 평균 점수를 0으로 설정합니다.`, 'INFO');
+                averages.set(repoName, 0);
+                return;
             }
-
+            
             const total = values.reduce((sum, val) => sum + val, 0);
             const average = total / values.length;
-
-            log(`${repoName} Average Score: ${average.toFixed(2)}\n`, 'INFO');
-            return average;
+            averages.set(repoName, average);
+            
+            log(`${repoName} Average Score: ${average.toFixed(2)}`, 'INFO');
         });
+        
+        return averages;
     }
 
     /**


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/443

## Specific Version
https://github.com/oss2025hnu/reposcore-js/commit/3c90eb0fcbb8eb569967f766ffdb63fca5dea635

## 변경 내용
- 참가자가 없는 경우 평균 점수를 0으로 설정
- 평균 점수를 Map 객체로 반환하도록 수정