### PR TITLE
[FEAT] 차트 생성 오류 스택 트레이스 추가 PR

### DIFF
--- a/lib/ChartGenerator.js
+++ b/lib/ChartGenerator.js
@@ -260,7 +260,7 @@ export class ChartGenerator {
             await fs.writeFile(filePath, buffer);
             log(`차트 이미지가 저장되었습니다: ${filePath}`);
         } catch (error) {
-            log(`차트 생성 중 오류 발생: ${error.message}`, 'ERROR');
+            log(`차트 생성 중 오류 발생: ${error.message}\n스택 트레이스: ${error.stack}`, 'ERROR');
             throw error;
         }
     }


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/442

## Specific Version
https://github.com/oss2025hnu/reposcore-js/commit/51853d4b1a3ded3465d046cd13cdea1fb79bd533

## 변경 내용
- ChartGenerator 클래스의 generateChart 메서드에서 오류 발생 시 로깅 기능을 개선했습니다.
- 기존에는 오류 메시지만 로깅했지만, 이제는 오류 메시지와 함께 스택 트레이스도 로깅하도록 수정했습니다.