### PR TITLE
[FEAT] CSV, HTML 파일에 Issue ratio(I)를 표시하도록 변경 PR

### DIFF
--- a/lib/csvGenerator.js
+++ b/lib/csvGenerator.js
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs/promises';
 import { log } from './Util.js';
 
-const CSV_HEADER = 'name,feat/bug PR count,feat/bug PR score,doc PR count,doc PR score,typo PR count,typo PR score,feat/bug issue count,feat/bug issue score,doc issue count,doc issue score,total\n';
+const CSV_HEADER = 'name,feat/bug PR count,feat/bug PR score,doc PR count,doc PR score,typo PR count,typo PR score,feat/bug issue count,feat/bug issue score,doc issue count,doc issue score,total,issue_ratio\n';
 
 class CsvGenerator {
     constructor() {}
@@ -24,7 +24,9 @@ class CsvGenerator {
             const scoreData = repoScores.find(([name]) => name === participant) || [participant, 0, 0, 0, 0, 0, 0];
             const [, p_fb_score, p_d_score, p_t_score, i_fb_score, i_d_score, total] = scoreData;
 
-            csvContent += `${participant},${p_fb_count},${p_fb_score},${p_d_count},${p_d_score},${p_t_count},${p_t_score},${i_fb_count},${i_fb_score},${i_d_count},${i_d_score},${total}\n`;
+            // Calculate issue ratio as a percentage
+            const issueRatio = total > 0 ? ((i_fb_score / total) * 100).toFixed(2) : '0.00';
+            csvContent += `${participant},${p_fb_count},${p_fb_score},${p_d_count},${p_d_score},${p_t_count},${p_t_score},${i_fb_count},${i_fb_score},${i_d_count},${i_d_score},${total},${issueRatio}%\n`;
             totalScore += total;
         }
 

--- a/lib/tableGenerator.js
+++ b/lib/tableGenerator.js
@@ -74,11 +74,12 @@ export default class TableGenerator {
                 16,           // feat/bug 이슈 점수
                 12,           // doc 이슈 점수
                 10,           // 총점
-                11            // 참여율(%)
+                11,           // 참여율(%)
+                11            // 이슈 비율(%)
             ];
 
             const table = new Table({
-                head: ['순위', '참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)'],
+                head: ['순위', '참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)', '이슈 비율(%)'],
                 colWidths: colWidths,
                 style: { 
                     head: theme.table.head,
@@ -111,6 +112,9 @@ export default class TableGenerator {
                 // 참여율 계산
                 const rate = calculateRate(total, totalScore);
 
+                // 이슈 비율 계산
+                const issueRatio = total > 0 ? ((i_fb_score / total) * 100).toFixed(2) : '0.00';
+
                 //뱃지
                 const badge = getBadge(total);
                 
@@ -133,7 +137,8 @@ export default class TableGenerator {
                     i_fb_score,
                     i_d_score,
                     total,
-                    `${rate}%`
+                    `${rate}%`,
+                    `${issueRatio}%`
                 ]);
             });
 


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/470

## Specific Version
https://github.com/oss2025hnu/reposcore-js/commit/0eb98f162ae58d8007cea53421fde117e589847c

## 변경 내용
- CSV 파일에 issue_ratio 컬럼 추가
- TableGenerator에 이슈 비율(%) 컬럼 추가
- 각 참가자별 이슈 비율 계산 로직 구현
- 그래프, CSV, HTML 간 결과물 일관성 유지