### PR TITLE
[FEAT] _combined.csv, .txt 파일 내용에 docRatio(D) 추가해주세요 PR

### DIFF
--- a/lib/csvGenerator.js
+++ b/lib/csvGenerator.js
@@ -3,7 +3,7 @@ import path from 'path';
 import fs from 'fs/promises';
 import { log } from './Util.js';
 
-const CSV_HEADER = 'name,feat/bug PR count,feat/bug PR score,doc PR count,doc PR score,typo PR count,typo PR score,feat/bug issue count,feat/bug issue score,doc issue count,doc issue score,total,issue_ratio\n';
+const CSV_HEADER = 'name,feat/bug PR count,feat/bug PR score,doc PR count,doc PR score,typo PR count,typo PR score,feat/bug issue count,feat/bug issue score,doc issue count,doc issue score,total,issue_ratio,doc_ratio\n';
 
 class CsvGenerator {
     constructor() {}
@@ -26,7 +26,9 @@ class CsvGenerator {
 
             // Calculate issue ratio as a percentage
             const issueRatio = total > 0 ? ((i_fb_score / total) * 100).toFixed(2) : '0.00';
-            csvContent += `${participant},${p_fb_count},${p_fb_score},${p_d_count},${p_d_score},${p_t_count},${p_t_score},${i_fb_count},${i_fb_score},${i_d_count},${i_d_score},${total},${issueRatio}%\n`;
+            // Calculate doc ratio as a percentage
+            const docRatio = total > 0 ? ((p_d_score / total) * 100).toFixed(2) : '0.00';
+            csvContent += `${participant},${p_fb_count},${p_fb_score},${p_d_count},${p_d_score},${p_t_count},${p_t_score},${i_fb_count},${i_fb_score},${i_d_count},${i_d_score},${total},${issueRatio}%,${docRatio}%\n`;
             totalScore += total;
         }
 

--- a/lib/tableGenerator.js
+++ b/lib/tableGenerator.js
@@ -75,11 +75,12 @@ export default class TableGenerator {
                 12,           // doc 이슈 점수
                 10,           // 총점
                 11,           // 참여율(%)
-                11            // 이슈 비율(%)
+                11,           // 이슈 비율(%)
+                11            // 문서 비율(%)
             ];
 
             const table = new Table({
-                head: ['순위', '참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)', '이슈 비율(%)'],
+                head: ['순위', '참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)', '이슈 비율(%)', '문서 비율(%)'],
                 colWidths: colWidths,
                 style: { 
                     head: theme.table.head,
@@ -114,6 +115,9 @@ export default class TableGenerator {
 
                 // 이슈 비율 계산
                 const issueRatio = total > 0 ? ((i_fb_score / total) * 100).toFixed(2) : '0.00';
+                
+                // 문서 비율 계산
+                const docRatio = total > 0 ? ((p_d_score / total) * 100).toFixed(2) : '0.00';
 
                 //뱃지
                 const badge = getBadge(total);
@@ -138,7 +142,8 @@ export default class TableGenerator {
                     i_d_score,
                     total,
                     `${rate}%`,
-                    `${issueRatio}%`
+                    `${issueRatio}%`,
+                    `${docRatio}%`
                 ]);
             });
 


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/476

## Specific Version
https://github.com/oss2025hnu/reposcore-js/commit/eda89c4ddcb2d23dfe5c6b7adae21ddfefebc345

## 변경 내용
- CSV 파일에 doc_ratio 컬럼 추가
- TableGenerator에 문서 비율(%) 컬럼 추가
- 소수점 둘째 자리까지 백분율로 표시
- 그래프, CSV, 텍스트 파일 간 결과물 일관성 유지