### PR TITLE
[BUG] _combined.csv 파일이름 다시 수정 PR

### DIFF
--- a/lib/csvGenerator.js
+++ b/lib/csvGenerator.js
@@ -34,7 +34,7 @@ class CsvGenerator {
 
         const repoSpecificDir = path.join(outputDir, repoName);
         await fs.mkdir(repoSpecificDir, { recursive: true });
-        const filePath = path.join(repoSpecificDir, `${repoName}_combined.csv`);
+        const filePath = path.join(repoSpecificDir, `${repoName}_data.csv`);
         await fs.writeFile(filePath, csvContent);
         log(`통합 CSV 파일이 생성되었습니다: ${filePath}`, 'INFO');
     }

--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -58,7 +58,7 @@ export async function generateHTML(repositories, resultsDir) {
         const repoName = tab === 'total' ? 'total' : tab.split('/')[1];
         const pngPath =  path.join(repoName, `${repoName}_chart.png`);
         const txtPath = path.join(resultsDir, repoName, `${repoName}.txt`);
-        const combinedCsvPath = path.join(repoName, `${repoName}_combined.csv`);
+        const dataCsvPath = path.join(repoName, `${repoName}_data.csv`);
 
         let txtContent;
         try {
@@ -75,7 +75,7 @@ export async function generateHTML(repositories, resultsDir) {
       <div style="display: flex; justify-content: space-between; align-items: center;">
           <h1 style="margin: 0;">${repoName}</h1>
           <div>
-            <a class="download-button" href="${combinedCsvPath}" download="${repoName}_combined.csv">Download Combined CSV</a>
+            <a class="download-button" href="${dataCsvPath}" download="${repoName}_data.csv">Download Data CSV</a>
           </div>
       </div>
       <div style="display: flex; gap: 20px; align-items: flex-start; margin-top: 20px;">


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/482

## Specific Version
https://github.com/oss2025hnu/reposcore-js/commit/6660d29d162af34eb7e1ad8adc6b25e9ba541353

## 변경 내용
- csvGenerator.js: _combined.csv를 _data.csv로 변경
- htmlGenerator.js: 
  - CSV 파일 경로를 _combined.csv에서 _data.csv로 변경
  - 다운로드 링크 텍스트를 "Download Combined CSV"에서 "Download Data CSV"로 변경
  - html도 안 깨지게 수정 완료.