### PR TITLE
HTML 테이블의 불필요한 행 제거

### DIFF
--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -17,15 +17,9 @@ function parseTableText(rawText) {
     const generatedLine = lines[1].trim();
 
     const tableDataLines = lines.slice(2);
+    tableDataLines.splice(1, 1);
 
-    // 점수만 반복되는 라인을 제거
-    const filteredTableLines = tableDataLines.filter(line => {
-    // '점수'만 포함된 열인지 확인 (공백, 선 등 고려)
-    const cols = line.split('│').map(col => col.trim()).filter(col => col.length > 0);
-    return !(cols.length > 0 && cols.every(col => col === '점수'));
-});
-
-    const tableRows = filteredTableLines.map(line => {
+    const tableRows = tableDataLines.map(line => {
         const cols = line.trim().split('│')
             .map(col => col.trim())
             .filter(col => col.length > 0);


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/489

## Specific Version
ac062488e02383631b585744a029d9ec48d2c458

## 변경 내용
기존 HTML 테이블에서 불필요하게 생성되던 '점수' 행을 제거하였습니다. 
`htmlGenerator.js`의 `generateHTML`의 `tableDataLines[1]`값을 삭제하여 해결하였습니다. 
![스크린샷 2025-05-17 225230](https://github.com/user-attachments/assets/fb5152a4-e689-46d9-bd7f-edcfb26f7531)

