### PR TITLE
장소가 1개일 때도 HTML에 total 분석이 출력되는 문제 해결

### DIFF
--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -52,7 +52,10 @@ function parseTableText(rawText) {
  */
 export async function generateHTML(repositories, resultsDir) {
     const validRepos = repositories.filter(repo => /^[^/\s]+\/[^/\s]+$/.test(repo));
-    const tabs = ['total', ...validRepos];
+    // 저장소가 2개 이상일 경우에만 total 포함
+    const tabs = repositories.length > 1
+      ? ['total', ...validRepos]
+      : validRepos;
 
     const tabContents = await Promise.all(tabs.map(async (tab) => {
         const repoName = tab === 'total' ? 'total' : tab.split('/')[1];


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/499

## Specific Version
ac062488e02383631b585744a029d9ec48d2c458 

## 변경 내용
`generateHTML()` 함수에서 `tabs` 배열을 구성할 때, 저장소가 **2개 이상**일 경우에만 `'total'` 탭을 포함하도록 조건을 추가했습니다.
이를 통해 단일 저장소 분석 시 불필요한 `'total'` 탭이 HTML에 생성되지 않도록 수정했습니다.