### PR TITLE
[REFACTOR] 차트와 .txt결과물에 출력되는 featRatio 수정 PR

### DIFF
--- a/lib/ChartGenerator.js
+++ b/lib/ChartGenerator.js
@@ -169,7 +169,7 @@ export class ChartGenerator {
                 subtitle: {
                     display: true,
                     text: [`Total number of student : ${participantCount}`,
-                        `F: featRatio / D: docRatio/ T: typoRatio/ I: Issue ratio`
+                        `F/B: feat/bug ratio / D: doc ratio / T: typo ratio / I: Issue ratio`
                     ],
                     align: 'end',
                     color: this.theme.chart.textColor,
@@ -207,10 +207,10 @@ export class ChartGenerator {
                         const issueRatio = totalScore > 0 ? ((prIssue / totalScore) * 100).toFixed(0) : 0;
 
                         if (maxScore > 200) {
-                            return `${totalScore} | F${featRatio}%/D${docRatio}%/T${typoRatio}%/I${issueRatio}%`;
+                            return `${totalScore} | F/B${featRatio}%/D${docRatio}%/T${typoRatio}%/I${issueRatio}%`;
                         }
 
-                        return `${totalScore} | F ${featRatio}% / D ${docRatio}% / T ${typoRatio}% / I ${issueRatio}%`;
+                        return `${totalScore} | F/B ${featRatio}% / D ${docRatio}% / T ${typoRatio}% / I ${issueRatio}%`;
                     }
                 }
             },

--- a/lib/tableGenerator.js
+++ b/lib/tableGenerator.js
@@ -88,7 +88,7 @@ export default class TableGenerator {
             ];
 
             const table = new Table({
-                head: ['순위', '참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)', 'feat 비율(%)', 'doc 비율(%)', '이슈 비율(%)'],
+                head: ['순위', '참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)', 'feat/bug 비율(%)', 'doc 비율(%)', '이슈 비율(%)'],
 
                 colWidths: colWidths,
                 style: { 


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/522

## Specific Version
https://github.com/oss2025hnu/reposcore-js/commit/c1133f743283e031524688e217c2f37436d6c295

## 변경 내용
TableGenerator.js:
- 테이블 헤더에서 'feat 비율(%)'을 'feat/bug 비율(%)'로 변경했습니다.

ChartGenerator.js:
- 차트의 데이터 라벨에서 'F'를 'F/B'로 변경했습니다.
- 서브타이틀을 'F: featRatio'에서 'F/B: feat/bug ratio'로 변경하여 더 명확하게 표시했습니다.