### PR TITLE
html 테이블 중복 출력 제거

### DIFF
--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -17,7 +17,7 @@ function parseTableText(rawText) {
     const generatedLine = lines[1].trim();
     
     const tableDataLines = lines.slice(2);
-    tableDataLines.splice(1, 1);
+    tableDataLines.splice(0, 4);
 
     // 총점 배열 생성
     const totalScores = tableDataLines

--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -18,6 +18,7 @@ function parseTableText(rawText) {
     
     const tableDataLines = lines.slice(2);
     tableDataLines.splice(0, 4);
+    tableDataLines.splice(1, 1);
 
     // 총점 배열 생성
     const totalScores = tableDataLines


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/518

## Specific Version
ac138a381ce3150406f7e4973c8fbf249057b766

## 변경 내용
`htmlGenerator.js` 에서 `tableDataLines.splice(0, 4);` 을 사용해 중복되는 행(평균/최저/최고 점수)을 삭제하였습니다. 

![스크린샷 2025-05-22 084450](https://github.com/user-attachments/assets/4877544a-53ec-4a71-8fc4-33bd08196a37)

삭제 후, 테이블이 올바르게 출력되는 모습을 보입니다.

