### PR TITLE
[BUG] 저장소가 1개일 때 HTML에 total 분석이 출력되는 문제

### DIFF
--- a/lib/htmlGenerator.js
+++ b/lib/htmlGenerator.js
@@ -68,7 +68,7 @@ function parseTableText(rawText) {
 export async function generateHTML(repositories, resultsDir) {
     const validRepos = repositories.filter(repo => /^[^/\s]+\/[^/\s]+$/.test(repo));
     // 저장소가 2개 이상일 경우에만 total 포함
-    const tabs = repositories.length > 1
+    const tabs = validRepos.length > 1
       ? ['total', ...validRepos]
       : validRepos;
 


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/528

## Specific Version
194aa6b2a43d8480ec97747e40b0314cc454b2f6

## 변경 내용
generateHTML() 함수에서 저장소 개수를 판단할 때 repositories.length 대신 validRepos.length를 사용하도록 수정했습니다.
이를 통해, 옵션이 포함된 경우에도 저장소가 1개일 때는 total 분석 탭이 생성되지 않도록 로직을 정정하였습니다.