### PR TITLE
csv 출력 버그 수정

### DIFF
--- a/lib/csvGenerator.js
+++ b/lib/csvGenerator.js
@@ -34,10 +34,9 @@ class CsvGenerator {
 
 
             totalScore += total;
-            csvContent += `${participant},
-            ${p_fb_count},${p_fb_score},${p_d_count},${p_d_score},${p_t_count},
-            ${p_t_score},${i_fb_count},${i_fb_score},${i_d_count},${i_d_score},
-            ${total},${featRatio},${docRatio},${issueRatio}\n`;
+            csvContent += `${participant},\
+            ${p_fb_count},${p_fb_score},${p_d_count},${p_d_score},${p_t_count},${p_t_score},\
+            ${i_fb_count},${i_fb_score},${i_d_count},${i_d_score},${total},${featRatio},${typoRatio},${docRatio},${issueRatio}\n`;
         }
 
         const repoSpecificDir = path.join(outputDir, repoName);


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/538

## Specific Version
e348462581036e1c6013e9b55a78a85bca097a83

## 변경 내용
csv파일을 생성하기 위해 `csvContent`의 문자열을 설정하는 과정에서 `(백틱)을 사용후 줄을 바꾸어 작성하여 csv문자열이 의도대로 작성되지 않았습니다. 문자열 사이에 \(역슬래시)를 삽입하여 줄바꿈을 무시하였습니다. 

수정이후 csv파일이 올바르게 생성됩니다.

![image](https://github.com/user-attachments/assets/3c032cda-0934-4523-b745-b245d506d75b)

