### PR TITLE
calculateScores() 중복 호출 제거

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,9 +173,7 @@ async function main() {
             realNameScore = await analyzer.transformUserIdToName(scores);
         }
 
-        const scoresMap = analyzer.calculateScores();
-
-        let filteredScores = scoresMap;
+        let filteredScores = scores;
 
         if (options.threshold !== undefined) {
             filteredScores = Array.from(filteredScores).map(([repo, scoreList]) => {
@@ -185,7 +183,7 @@ async function main() {
         }
 
        if (options.user) {
-            const allScoresRaw = Array.from(scoresMap.entries()); // [repoName, [[user1], ...]]
+            const allScoresRaw = Array.from(scores.entries()); // Use scores instead of scoresMap
             const userScores = new Map(); // username → { total: number, perRepo: Map }
 
             for (const [repoName, users] of allScoresRaw) {
@@ -247,13 +245,13 @@ async function main() {
         }
         
 
-        const averageScores = analyzer.calculateAverageScore(scoresMap);
+        const averageScores = analyzer.calculateAverageScore(scores); // Use scores instead of scoresMap
         await fs.mkdir(options.output, { recursive: true });
         log(`총 ${program.args.length}개의 저장소 분석을 시작합니다.`, 'INFO');
 
         let totalEntry = null; // total 저장소 따로 저장
 
-        for (const [repoName, scoreData] of scoresMap.entries()) {
+        for (const [repoName, scoreData] of scores.entries()) { // Use scores instead of scoresMap
             if (repoName === 'total') {
                 totalEntry = { repoName, scoreData };
                 continue; // total은 나중에 따로 처리


### PR DESCRIPTION
## Issue ID 
https://github.com/oss2025hnu/reposcore-js/issues/555

## Specific Version
https://github.com/oss2025hnu/reposcore-js/commit/ad51d0a31e3f0a855606a47c3b4fe95cae13e7ed

## 변경 내용
- scores와 scoresMap 두 변수 모두에서 analyzer.calculateScores()를 호출하던 부분 중복 제거

기존:
``` javascript
const scores = analyzer.calculateScores();
// ...
const scoresMap = analyzer.calculateScores();  // 중복 호출
```

변경:
``` javascript
const scores = analyzer.calculateScores();
// 이후 로직에서 scoresMap 대신 모두 `scores` 사용
```

- 코드 전반에서 scoresMap 참조를 scores로 일괄 변경
- 함수 내부에서 scoresMap.get(...) 형태로 사용하던 부분을 scores.get(...)으로 수정
- 관련 주석과 변수명을 명확히 수정하여 가독성 향상
