### PR TITLE
--colored-output 옵션 개선

### DIFF
--- a/lib/tableGenerator.js
+++ b/lib/tableGenerator.js
@@ -164,7 +164,7 @@ export default class TableGenerator {
                         lte: 60,
                         color: {
                             r: 0xff,
-                            g: 0xff,
+                            g: 0x5a,
                             b: 0x00
                         }
                     },

--- a/lib/tableGenerator.js
+++ b/lib/tableGenerator.js
@@ -101,12 +101,8 @@ export default class TableGenerator {
 
             // 하위 70% 구분을 위한 기준 인덱스 (상위 30% 제외)
             const shouldColor = options?.coloredOutput;
-            const highlightStartIndex = Math.ceil(repoScores.length * 0.3);
-            function getRandomRGB() {
-            const r = Math.floor(Math.random() * 156 + 100);  // 밝은 색 위주
-            const g = Math.floor(Math.random() * 156 + 100);
-            const b = Math.floor(Math.random() * 156 + 100);
-            return `\x1b[38;2;${r};${g};${b}m`; // ANSI escape code for RGB
+            function getRGB(r, g, b) {
+                return `\x1b[38;2;${r};${g};${b}m`; // ANSI escape code for RGB
             }
 
             // 리포지토리 전체 합(= 모든 기여자의 totalScore 합)
@@ -141,9 +137,69 @@ export default class TableGenerator {
                 // 뱃지에서 이모지만 추출
                 const badgeEmoji = badge.split(' ')[0];
 
-                // 하위 70%면 랜덤 색상 적용
-                const isBottom = index >= highlightStartIndex;
-                const coloredName = isBottom ? getRandomRGB() + name + '\x1b[0m' : name;
+                const ranges = [
+                    // [0, 10], Green
+                    {
+                        gte: 0,
+                        lte: 10,
+                        color: {
+                            r: 0x00,
+                            g: 0xff,
+                            b: 0x00
+                        }
+                    },
+                    // [11, 30], Yellow
+                    {
+                        gte: 11,
+                        lte: 30,
+                        color: {
+                            r: 0xff,
+                            g: 0xff,
+                            b: 0x00
+                        }
+                    },
+                    // [31, 60], Orange
+                    {
+                        gte: 31,
+                        lte: 60,
+                        color: {
+                            r: 0xff,
+                            g: 0xff,
+                            b: 0x00
+                        }
+                    },
+                    // [61, 80], Red
+                    {
+                        gte: 61,
+                        lte: 80,
+                        color: {
+                            r: 0xff,
+                            g: 0x00,
+                            b: 0x00
+                        }
+                    },
+                    // [81, 100], Gray
+                    {
+                        gte: 81,
+                        lte: 100,
+                        color: {
+                            r: 0x80,
+                            g: 0x80,
+                            b: 0x80
+                        }
+                    },
+                ];
+                let color;
+                for (const range of ranges) {
+                    const {gte, lte} = range;
+                    // console.log(index, Math.ceil(index / repoScores.length * 100), gte, lte);
+                    const rank = Math.ceil(index / repoScores.length * 100);
+                    if(rank >= gte && rank <= lte) {  
+                        color = range.color;
+                        break;
+                    }
+                }
+                const coloredName = getRGB(color.r, color.g, color.b) + name + '\x1b[0m';
 
                 const nameWithBadge = `${badgeEmoji} ${coloredName}`;
 


### PR DESCRIPTION
## Issue ID 
#546

## Specific Version
673d06cd6ea3b0992fc4a2ad6072b5e0975bf66c

## 변경 내용
- `--colored-output` 옵션 개선
  - 상위 10%: 🟢 초록색(00ff00)
  - 상위 11-30%: 🟡 노란색 (ffff00)
  - 상위 31-60%: 🟠 주황색 (ff5a00)
  - 상위 61-80%: 🔴 빨간색 (ff0000)
  - 하위 81-100%: ⚫ 회색 (808080)