### PR TITLE
항목별 비율(%)의 합이 100%가 되도록 수정

### DIFF
--- a/lib/tableGenerator.js
+++ b/lib/tableGenerator.js
@@ -82,15 +82,20 @@ export default class TableGenerator {
                 12,           // doc 이슈 점수
                 10,           // 총점
                 11,           // 참여율(%)
-                11,           // feat 비율(%)
-                11,           // typo 비율(%)
-                11,           // doc 비율(%)
-                11            // 이슈 비율(%)
+                11,           // feat/bug PR 비율(%)
+                11,           // doc PR 비율(%)
+                11,           // typo PR 비율(%)
+                11,           // feat/bug 이슈 비율(%)
+                11            // doc 이슈 비율(%)
             ];
 
             const table = new Table({
-                head: ['순위', '참가자', 'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수', '총점', '참여율(%)', 'feat/bug 비율(%)', 'typo 비율(%)', 'doc 비율(%)', '이슈 비율(%)'],
-
+                head: [
+                    '순위', '참가자',
+                    'feat/bug PR 점수', 'doc PR 점수', 'typo PR 점수', 'feat/bug 이슈 점수', 'doc 이슈 점수',
+                    '총점', '참여율(%)',
+                    'feat/bug PR 비율(%)', 'doc PR 비율(%)', 'typo PR 비율(%)', 'feat/bug 이슈 비율(%)', 'doc 이슈 비율(%)'
+                ],
                 colWidths: colWidths,
                 style: { 
                     head: theme.table.head,
@@ -103,41 +108,38 @@ export default class TableGenerator {
             const shouldColor = options?.coloredOutput;
             const highlightStartIndex = Math.ceil(repoScores.length * 0.3);
             function getRandomRGB() {
-            const r = Math.floor(Math.random() * 156 + 100);  // 밝은 색 위주
-            const g = Math.floor(Math.random() * 156 + 100);
-            const b = Math.floor(Math.random() * 156 + 100);
-            return `\x1b[38;2;${r};${g};${b}m`; // ANSI escape code for RGB
+                const r = Math.floor(Math.random() * 156 + 100);  // 밝은 색 위주
+                const g = Math.floor(Math.random() * 156 + 100);
+                const b = Math.floor(Math.random() * 156 + 100);
+                return `\x1b[38;2;${r};${g};${b}m`; // ANSI escape code for RGB
             }
 
             // 리포지토리 전체 합(= 모든 기여자의 totalScore 합)
-            const totalScore = repoScores.reduce((sum, row) => sum + row[6], 0); // 변경: totalScore 인덱스 6으로 조정
+            const totalScore = repoScores.reduce((sum, row) => sum + row[6], 0); // total 인덱스 6
 
             // 텍스트 파일로 저장하기 위해 문자열 준비
             let prevTotal = null;
             let rank = 0;
-            repoScores.forEach(([name, p_fb_score, p_d_score, p_t_score, i_fb_score, i_d_score, total], index) => { // 변경: p_t_score 추가
+            repoScores.forEach(([name, p_fb_score, p_d_score, p_t_score, i_fb_score, i_d_score, total], index) => {
+                // 5개 항목 점수 합
+                const sum = p_fb_score + p_d_score + p_t_score + i_fb_score + i_d_score;
+
+                // 각 항목별 비율 (합이 100%가 되도록)
+                const p_fb_ratio = sum > 0 ? ((p_fb_score / sum) * 100).toFixed(2) : '0.00';
+                const p_d_ratio = sum > 0 ? ((p_d_score / sum) * 100).toFixed(2) : '0.00';
+                const p_t_ratio = sum > 0 ? ((p_t_score / sum) * 100).toFixed(2) : '0.00';
+                const i_fb_ratio = sum > 0 ? ((i_fb_score / sum) * 100).toFixed(2) : '0.00';
+                const i_d_ratio = sum > 0 ? ((i_d_score / sum) * 100).toFixed(2) : '0.00';
+
                 // 순위 계산
                 rank = calculateRank(index, total, prevTotal, rank);
                 prevTotal = total;
 
-                // 참여율 계산
+                // 참여율 계산 (전체 총점 대비 개인 총점 비율)
                 const rate = calculateRate(total, totalScore);
 
-                // feat비율 계산
-                const featRatio = total > 0 ? ((p_fb_score / total) * 100).toFixed(1) : '0.0';
-
-                // typo 비율 계산
-                const typoRatio = total > 0 ? ((p_t_score / total) * 100).toFixed(2) : '0.00';
-
-                // 이슈 비율 계산
-                const issueRatio = total > 0 ? ((i_fb_score / total) * 100).toFixed(2) : '0.00';
-                
-                // 문서 비율 계산
-                const docRatio = total > 0 ? ((p_d_score / total) * 100).toFixed(2) : '0.00';
-
-                //뱃지
+                // 뱃지
                 const badge = getBadge(total);
-                
                 // 뱃지에서 이모지만 추출
                 const badgeEmoji = badge.split(' ')[0];
 
@@ -153,15 +155,16 @@ export default class TableGenerator {
                     nameWithBadge,
                     p_fb_score,
                     p_d_score,
-                    p_t_score, // 추가
+                    p_t_score,
                     i_fb_score,
                     i_d_score,
                     total,
                     `${rate}%`,
-                    `${featRatio}%`,
-                    `${typoRatio}%`,
-                    `${docRatio}%`,
-                    `${issueRatio}%`
+                    `${p_fb_ratio}%`,
+                    `${p_d_ratio}%`,
+                    `${p_t_ratio}%`,
+                    `${i_fb_ratio}%`,
+                    `${i_d_ratio}%`
                 ]);
             });
 
@@ -200,11 +203,12 @@ export default class TableGenerator {
 
             // 콘솔 출력 (옵션 있을 때만 컬러포함 출력)
             if (shouldColor) {
-            console.log(finalOutput);
+                console.log(finalOutput);
             }
 
             // ANSI escape code 제거하고 파일로 저장
             await fs.writeFile(filePath, stripAnsi(finalOutput), 'utf-8');
+            log(`점수 집계 텍스트 파일이 생성되었습니다: ${filePath}`, 'INFO');
         });
 
         await Promise.all(promises);


### PR DESCRIPTION
## Issue ID 
#557 

## Specific Version
63d7267

## 변경 내용
- feat/bug PR, doc PR, typo PR, feat/bug 이슈, doc 이슈 각 항목별 비율(%)을 전체 항목 점수 합(sum) 기준으로 계산하도록 수정했습니다.
- 기존에는 각 항목 비율을 개인 총점으로 나누어 계산해, 비율의 합이 100%가 되지 않는 문제가 있었습니다.